### PR TITLE
add --device for word_language_model

### DIFF
--- a/word_language_model/README.md
+++ b/word_language_model/README.md
@@ -37,6 +37,7 @@ optional arguments:
   --seed SEED           random seed
   --cuda                use CUDA
   --mps                 enable GPU on macOS
+  --device DEVICE       backend device
   --log-interval N      report interval
   --save SAVE           path to save the final model
   --onnx-export ONNX_EXPORT
@@ -53,4 +54,10 @@ python main.py --cuda --emsize 650 --nhid 650 --dropout 0.5 --epochs 40
 python main.py --cuda --emsize 650 --nhid 650 --dropout 0.5 --epochs 40 --tied
 python main.py --cuda --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40
 python main.py --cuda --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40 --tied
+```
+
+You can also use non-cuda devices like this:
+
+```bash
+python main.py --device npu --emsize 650 --nhid 650 --dropout 0.5 --epochs 40
 ```

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -23,6 +23,8 @@ parser.add_argument('--seed', type=int, default=1111,
                     help='random seed')
 parser.add_argument('--cuda', action='store_true',
                     help='use CUDA')
+parser.add_argument('--device', type=str, default='cpu',
+                    help='backend device')
 parser.add_argument('--mps', action='store_true', default=False,
                         help='enables macOS GPU training')
 parser.add_argument('--temperature', type=float, default=1.0,
@@ -46,7 +48,7 @@ if args.cuda:
 elif use_mps:
     device = torch.device("mps")
 else:
-    device = torch.device("cpu")
+    device = torch.device(args.device)
 
 if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3.")

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -40,7 +40,9 @@ parser.add_argument('--seed', type=int, default=1111,
 parser.add_argument('--cuda', action='store_true', default=False,
                     help='use CUDA')
 parser.add_argument('--mps', action='store_true', default=False,
-                        help='enables macOS GPU training')
+                    help='enables macOS GPU training')
+parser.add_argument('--device', type=str, default='cpu',
+                    help='backend device')
 parser.add_argument('--log-interval', type=int, default=200, metavar='N',
                     help='report interval')
 parser.add_argument('--save', type=str, default='model.pt',
@@ -68,7 +70,7 @@ if args.cuda:
 elif use_mps:
     device = torch.device("mps")
 else:
-    device = torch.device("cpu")
+    device = torch.device(args.device)
 
 ###############################################################################
 # Load data


### PR DESCRIPTION
Command:

```bash
$ python main.py --emsize 650 --nhid 650 --dropout 0.5 --epochs 40 --device npu
```

Log snippet:

```
-----------------------------------------------------------------------------------------
| epoch  40 |   200/ 2983 batches | lr 0.02 | ms/batch 38.69 | loss  3.73 | ppl    41.61
| epoch  40 |   400/ 2983 batches | lr 0.02 | ms/batch 38.45 | loss  3.76 | ppl    43.07
| epoch  40 |   600/ 2983 batches | lr 0.02 | ms/batch 38.71 | loss  3.57 | ppl    35.64
| epoch  40 |   800/ 2983 batches | lr 0.02 | ms/batch 38.69 | loss  3.64 | ppl    38.05
| epoch  40 |  1000/ 2983 batches | lr 0.02 | ms/batch 39.55 | loss  3.64 | ppl    38.25
| epoch  40 |  1200/ 2983 batches | lr 0.02 | ms/batch 39.65 | loss  3.65 | ppl    38.42
| epoch  40 |  1400/ 2983 batches | lr 0.02 | ms/batch 39.23 | loss  3.67 | ppl    39.14
| epoch  40 |  1600/ 2983 batches | lr 0.02 | ms/batch 39.26 | loss  3.74 | ppl    41.92
| epoch  40 |  1800/ 2983 batches | lr 0.02 | ms/batch 39.22 | loss  3.63 | ppl    37.60
| epoch  40 |  2000/ 2983 batches | lr 0.02 | ms/batch 38.86 | loss  3.63 | ppl    37.70
| epoch  40 |  2200/ 2983 batches | lr 0.02 | ms/batch 38.80 | loss  3.50 | ppl    33.17
| epoch  40 |  2400/ 2983 batches | lr 0.02 | ms/batch 39.11 | loss  3.53 | ppl    34.16
| epoch  40 |  2600/ 2983 batches | lr 0.02 | ms/batch 39.10 | loss  3.56 | ppl    35.00
| epoch  40 |  2800/ 2983 batches | lr 0.02 | ms/batch 39.03 | loss  3.52 | ppl    33.68
-----------------------------------------------------------------------------------------
| end of epoch  40 | time: 119.01s | valid loss  4.63 | valid ppl   102.46
-----------------------------------------------------------------------------------------
=========================================================================================
| End of training | test loss  4.58 | test ppl    97.34
=========================================================================================
```

<details>
<summary>Details</summary>

```
root@3dfeb58e2e6e:~/pytorch-examples/word_language_model# python main.py --emsize 650 --nhid 650 --dropout 0.5 --epochs 40 --device npu
[W919 06:20:15.994529222 OperatorEntry.cpp:155] Warning: Warning only once for all operators,  other operators may also be overridden.
  Overriding a previously registered kernel for the same operator and the same dispatch key
  operator: aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
    registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
  dispatch key: CPU
  previous kernel: registered at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:497
       new kernel: registered at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:100 (function operator())
| epoch   1 |   200/ 2983 batches | lr 20.00 | ms/batch 110.62 | loss  7.73 | ppl  2274.74
| epoch   1 |   400/ 2983 batches | lr 20.00 | ms/batch 39.09 | loss  6.80 | ppl   900.73
| epoch   1 |   600/ 2983 batches | lr 20.00 | ms/batch 38.79 | loss  6.42 | ppl   611.91
| epoch   1 |   800/ 2983 batches | lr 20.00 | ms/batch 38.79 | loss  6.24 | ppl   513.90
| epoch   1 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.77 | loss  6.11 | ppl   448.26
| epoch   1 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.87 | loss  6.04 | ppl   417.99
| epoch   1 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.84 | loss  5.93 | ppl   377.99
| epoch   1 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.81 | loss  5.94 | ppl   378.51
| epoch   1 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.84 | loss  5.77 | ppl   321.96
| epoch   1 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.89 | loss  5.74 | ppl   312.38
| epoch   1 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.85 | loss  5.64 | ppl   280.34
| epoch   1 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.81 | loss  5.64 | ppl   280.84
| epoch   1 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.93 | loss  5.62 | ppl   276.69
| epoch   1 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.82 | loss  5.50 | ppl   245.57
-----------------------------------------------------------------------------------------
| end of epoch   1 | time: 133.36s | valid loss  5.45 | valid ppl   233.21
-----------------------------------------------------------------------------------------
| epoch   2 |   200/ 2983 batches | lr 20.00 | ms/batch 39.03 | loss  5.51 | ppl   247.67
| epoch   2 |   400/ 2983 batches | lr 20.00 | ms/batch 38.85 | loss  5.49 | ppl   242.32
| epoch   2 |   600/ 2983 batches | lr 20.00 | ms/batch 38.86 | loss  5.31 | ppl   201.44
| epoch   2 |   800/ 2983 batches | lr 20.00 | ms/batch 38.79 | loss  5.32 | ppl   204.89
| epoch   2 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  5.29 | ppl   197.99
| epoch   2 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  5.27 | ppl   194.79
| epoch   2 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.62 | loss  5.27 | ppl   194.16
| epoch   2 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.61 | loss  5.33 | ppl   206.40
| epoch   2 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.69 | loss  5.18 | ppl   178.15
| epoch   2 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.73 | loss  5.20 | ppl   181.31
| epoch   2 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.66 | loss  5.10 | ppl   163.22
| epoch   2 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.65 | loss  5.12 | ppl   167.28
| epoch   2 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  5.13 | ppl   168.79
| epoch   2 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.63 | loss  5.04 | ppl   154.71
-----------------------------------------------------------------------------------------
| end of epoch   2 | time: 118.17s | valid loss  5.20 | valid ppl   181.60
-----------------------------------------------------------------------------------------
| epoch   3 |   200/ 2983 batches | lr 20.00 | ms/batch 39.11 | loss  5.09 | ppl   162.51
| epoch   3 |   400/ 2983 batches | lr 20.00 | ms/batch 38.87 | loss  5.10 | ppl   163.85
| epoch   3 |   600/ 2983 batches | lr 20.00 | ms/batch 38.85 | loss  4.91 | ppl   135.83
| epoch   3 |   800/ 2983 batches | lr 20.00 | ms/batch 38.68 | loss  4.96 | ppl   142.40
| epoch   3 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  4.94 | ppl   140.25
| epoch   3 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.76 | loss  4.94 | ppl   139.35
| epoch   3 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.78 | loss  4.96 | ppl   142.45
| epoch   3 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.77 | loss  5.03 | ppl   152.37
| epoch   3 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.74 | loss  4.89 | ppl   132.69
| epoch   3 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.70 | loss  4.92 | ppl   137.61
| epoch   3 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.73 | loss  4.82 | ppl   123.75
| epoch   3 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.72 | loss  4.84 | ppl   126.90
| epoch   3 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.67 | loss  4.86 | ppl   128.76
| epoch   3 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.76 | loss  4.79 | ppl   119.73
-----------------------------------------------------------------------------------------
| end of epoch   3 | time: 118.28s | valid loss  4.97 | valid ppl   143.73
-----------------------------------------------------------------------------------------
| epoch   4 |   200/ 2983 batches | lr 20.00 | ms/batch 38.97 | loss  4.84 | ppl   126.48
| epoch   4 |   400/ 2983 batches | lr 20.00 | ms/batch 38.70 | loss  4.86 | ppl   128.81
| epoch   4 |   600/ 2983 batches | lr 20.00 | ms/batch 38.68 | loss  4.66 | ppl   106.16
| epoch   4 |   800/ 2983 batches | lr 20.00 | ms/batch 38.72 | loss  4.73 | ppl   113.16
| epoch   4 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.76 | loss  4.72 | ppl   111.77
| epoch   4 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  4.72 | ppl   112.12
| epoch   4 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.74 | loss  4.76 | ppl   116.39
| epoch   4 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.68 | loss  4.82 | ppl   124.58
| epoch   4 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.65 | loss  4.69 | ppl   108.87
| epoch   4 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.69 | loss  4.73 | ppl   113.13
| epoch   4 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.69 | loss  4.62 | ppl   101.44
| epoch   4 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.68 | loss  4.65 | ppl   104.12
| epoch   4 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.74 | loss  4.67 | ppl   106.99
| epoch   4 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.79 | loss  4.60 | ppl    99.17
-----------------------------------------------------------------------------------------
| end of epoch   4 | time: 118.16s | valid loss  4.89 | valid ppl   132.75
-----------------------------------------------------------------------------------------
| epoch   5 |   200/ 2983 batches | lr 20.00 | ms/batch 38.92 | loss  4.66 | ppl   105.12
| epoch   5 |   400/ 2983 batches | lr 20.00 | ms/batch 38.66 | loss  4.69 | ppl   108.42
| epoch   5 |   600/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  4.49 | ppl    89.27
| epoch   5 |   800/ 2983 batches | lr 20.00 | ms/batch 38.62 | loss  4.56 | ppl    95.21
| epoch   5 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.66 | loss  4.55 | ppl    94.64
| epoch   5 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.63 | loss  4.56 | ppl    95.77
| epoch   5 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.65 | loss  4.59 | ppl    98.90
| epoch   5 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.73 | loss  4.68 | ppl   107.33
| epoch   5 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.59 | loss  4.54 | ppl    93.82
| epoch   5 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.63 | loss  4.58 | ppl    97.52
| epoch   5 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.79 | loss  4.46 | ppl    86.90
| epoch   5 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.68 | loss  4.50 | ppl    90.29
| epoch   5 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.65 | loss  4.53 | ppl    92.63
| epoch   5 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.77 | loss  4.46 | ppl    86.75
-----------------------------------------------------------------------------------------
| end of epoch   5 | time: 118.10s | valid loss  4.84 | valid ppl   126.32
-----------------------------------------------------------------------------------------
| epoch   6 |   200/ 2983 batches | lr 20.00 | ms/batch 38.91 | loss  4.52 | ppl    92.06
| epoch   6 |   400/ 2983 batches | lr 20.00 | ms/batch 38.83 | loss  4.55 | ppl    94.21
| epoch   6 |   600/ 2983 batches | lr 20.00 | ms/batch 38.86 | loss  4.36 | ppl    78.04
| epoch   6 |   800/ 2983 batches | lr 20.00 | ms/batch 38.73 | loss  4.42 | ppl    82.87
| epoch   6 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.75 | loss  4.42 | ppl    83.08
| epoch   6 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.72 | loss  4.43 | ppl    84.04
| epoch   6 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.76 | loss  4.47 | ppl    87.03
| epoch   6 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.70 | loss  4.55 | ppl    94.59
| epoch   6 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.79 | loss  4.42 | ppl    83.05
| epoch   6 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.75 | loss  4.46 | ppl    86.37
| epoch   6 |  2200/ 2983 batches | lr 20.00 | ms/batch 39.11 | loss  4.34 | ppl    76.90
| epoch   6 |  2400/ 2983 batches | lr 20.00 | ms/batch 39.00 | loss  4.38 | ppl    79.97
| epoch   6 |  2600/ 2983 batches | lr 20.00 | ms/batch 39.01 | loss  4.40 | ppl    81.75
| epoch   6 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.79 | loss  4.35 | ppl    77.52
-----------------------------------------------------------------------------------------
| end of epoch   6 | time: 118.51s | valid loss  4.83 | valid ppl   125.15
-----------------------------------------------------------------------------------------
| epoch   7 |   200/ 2983 batches | lr 20.00 | ms/batch 39.17 | loss  4.40 | ppl    81.59
| epoch   7 |   400/ 2983 batches | lr 20.00 | ms/batch 38.64 | loss  4.43 | ppl    83.76
| epoch   7 |   600/ 2983 batches | lr 20.00 | ms/batch 39.07 | loss  4.24 | ppl    69.64
| epoch   7 |   800/ 2983 batches | lr 20.00 | ms/batch 38.95 | loss  4.30 | ppl    74.05
| epoch   7 |  1000/ 2983 batches | lr 20.00 | ms/batch 39.09 | loss  4.31 | ppl    74.40
| epoch   7 |  1200/ 2983 batches | lr 20.00 | ms/batch 39.15 | loss  4.33 | ppl    75.67
| epoch   7 |  1400/ 2983 batches | lr 20.00 | ms/batch 39.13 | loss  4.36 | ppl    78.64
| epoch   7 |  1600/ 2983 batches | lr 20.00 | ms/batch 39.04 | loss  4.44 | ppl    84.85
| epoch   7 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.83 | loss  4.32 | ppl    74.82
| epoch   7 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.88 | loss  4.36 | ppl    78.26
| epoch   7 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.83 | loss  4.24 | ppl    69.60
| epoch   7 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.81 | loss  4.28 | ppl    72.58
| epoch   7 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.64 | loss  4.31 | ppl    74.54
| epoch   7 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.75 | loss  4.25 | ppl    70.35
-----------------------------------------------------------------------------------------
| end of epoch   7 | time: 118.70s | valid loss  4.78 | valid ppl   119.30
-----------------------------------------------------------------------------------------
| epoch   8 |   200/ 2983 batches | lr 20.00 | ms/batch 38.92 | loss  4.31 | ppl    74.39
| epoch   8 |   400/ 2983 batches | lr 20.00 | ms/batch 38.72 | loss  4.34 | ppl    76.73
| epoch   8 |   600/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  4.16 | ppl    63.83
| epoch   8 |   800/ 2983 batches | lr 20.00 | ms/batch 38.81 | loss  4.21 | ppl    67.58
| epoch   8 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.91 | loss  4.22 | ppl    68.12
| epoch   8 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.68 | loss  4.24 | ppl    69.65
| epoch   8 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.72 | loss  4.27 | ppl    71.86
| epoch   8 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.77 | loss  4.36 | ppl    78.12
| epoch   8 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.80 | loss  4.24 | ppl    69.54
| epoch   8 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.81 | loss  4.28 | ppl    72.56
| epoch   8 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.59 | loss  4.16 | ppl    64.14
| epoch   8 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.73 | loss  4.20 | ppl    66.63
| epoch   8 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.74 | loss  4.23 | ppl    68.85
| epoch   8 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.65 | loss  4.18 | ppl    65.34
-----------------------------------------------------------------------------------------
| end of epoch   8 | time: 118.23s | valid loss  4.78 | valid ppl   118.80
-----------------------------------------------------------------------------------------
| epoch   9 |   200/ 2983 batches | lr 20.00 | ms/batch 38.86 | loss  4.23 | ppl    68.70
| epoch   9 |   400/ 2983 batches | lr 20.00 | ms/batch 38.81 | loss  4.26 | ppl    70.71
| epoch   9 |   600/ 2983 batches | lr 20.00 | ms/batch 38.76 | loss  4.08 | ppl    58.93
| epoch   9 |   800/ 2983 batches | lr 20.00 | ms/batch 38.70 | loss  4.13 | ppl    62.22
| epoch   9 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.63 | loss  4.15 | ppl    63.58
| epoch   9 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  4.17 | ppl    64.52
| epoch   9 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.76 | loss  4.20 | ppl    66.89
| epoch   9 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  4.28 | ppl    72.35
| epoch   9 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.85 | loss  4.17 | ppl    65.00
| epoch   9 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.67 | loss  4.21 | ppl    67.32
| epoch   9 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.67 | loss  4.08 | ppl    59.42
| epoch   9 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.69 | loss  4.14 | ppl    62.56
| epoch   9 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.66 | loss  4.16 | ppl    63.91
| epoch   9 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.57 | loss  4.11 | ppl    61.01
-----------------------------------------------------------------------------------------
| end of epoch   9 | time: 118.15s | valid loss  4.77 | valid ppl   118.05
-----------------------------------------------------------------------------------------
| epoch  10 |   200/ 2983 batches | lr 20.00 | ms/batch 39.01 | loss  4.16 | ppl    64.31
| epoch  10 |   400/ 2983 batches | lr 20.00 | ms/batch 38.73 | loss  4.20 | ppl    66.48
| epoch  10 |   600/ 2983 batches | lr 20.00 | ms/batch 38.82 | loss  4.01 | ppl    55.20
| epoch  10 |   800/ 2983 batches | lr 20.00 | ms/batch 38.84 | loss  4.06 | ppl    58.02
| epoch  10 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.79 | loss  4.09 | ppl    59.76
| epoch  10 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.68 | loss  4.10 | ppl    60.54
| epoch  10 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.70 | loss  4.14 | ppl    63.03
| epoch  10 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.70 | loss  4.22 | ppl    68.37
| epoch  10 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.72 | loss  4.11 | ppl    60.90
| epoch  10 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.67 | loss  4.15 | ppl    63.36
| epoch  10 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.74 | loss  4.02 | ppl    55.84
| epoch  10 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.67 | loss  4.07 | ppl    58.56
| epoch  10 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.72 | loss  4.10 | ppl    60.28
| epoch  10 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.61 | loss  4.06 | ppl    57.76
-----------------------------------------------------------------------------------------
| end of epoch  10 | time: 118.16s | valid loss  4.76 | valid ppl   116.86
-----------------------------------------------------------------------------------------
| epoch  11 |   200/ 2983 batches | lr 20.00 | ms/batch 38.97 | loss  4.11 | ppl    60.76
| epoch  11 |   400/ 2983 batches | lr 20.00 | ms/batch 38.69 | loss  4.13 | ppl    62.46
| epoch  11 |   600/ 2983 batches | lr 20.00 | ms/batch 38.74 | loss  3.95 | ppl    51.93
| epoch  11 |   800/ 2983 batches | lr 20.00 | ms/batch 38.69 | loss  4.01 | ppl    55.22
| epoch  11 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.66 | loss  4.03 | ppl    56.52
| epoch  11 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.60 | loss  4.05 | ppl    57.67
| epoch  11 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.71 | loss  4.09 | ppl    59.64
| epoch  11 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.66 | loss  4.17 | ppl    64.53
| epoch  11 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.73 | loss  4.06 | ppl    58.00
| epoch  11 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.70 | loss  4.10 | ppl    60.07
| epoch  11 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.76 | loss  3.97 | ppl    53.14
| epoch  11 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.65 | loss  4.02 | ppl    55.88
| epoch  11 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.76 | loss  4.05 | ppl    57.42
| epoch  11 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.80 | loss  4.01 | ppl    55.06
-----------------------------------------------------------------------------------------
| end of epoch  11 | time: 118.14s | valid loss  4.75 | valid ppl   116.06
-----------------------------------------------------------------------------------------
| epoch  12 |   200/ 2983 batches | lr 20.00 | ms/batch 38.97 | loss  4.05 | ppl    57.67
| epoch  12 |   400/ 2983 batches | lr 20.00 | ms/batch 38.69 | loss  4.09 | ppl    59.50
| epoch  12 |   600/ 2983 batches | lr 20.00 | ms/batch 38.59 | loss  3.91 | ppl    49.72
| epoch  12 |   800/ 2983 batches | lr 20.00 | ms/batch 38.62 | loss  3.96 | ppl    52.48
| epoch  12 |  1000/ 2983 batches | lr 20.00 | ms/batch 38.67 | loss  3.99 | ppl    53.88
| epoch  12 |  1200/ 2983 batches | lr 20.00 | ms/batch 38.59 | loss  4.00 | ppl    54.79
| epoch  12 |  1400/ 2983 batches | lr 20.00 | ms/batch 38.46 | loss  4.04 | ppl    56.87
| epoch  12 |  1600/ 2983 batches | lr 20.00 | ms/batch 38.31 | loss  4.12 | ppl    61.54
| epoch  12 |  1800/ 2983 batches | lr 20.00 | ms/batch 38.26 | loss  4.02 | ppl    55.51
| epoch  12 |  2000/ 2983 batches | lr 20.00 | ms/batch 38.51 | loss  4.05 | ppl    57.27
| epoch  12 |  2200/ 2983 batches | lr 20.00 | ms/batch 38.42 | loss  3.93 | ppl    50.79
| epoch  12 |  2400/ 2983 batches | lr 20.00 | ms/batch 38.41 | loss  3.98 | ppl    53.35
| epoch  12 |  2600/ 2983 batches | lr 20.00 | ms/batch 38.29 | loss  4.00 | ppl    54.82
| epoch  12 |  2800/ 2983 batches | lr 20.00 | ms/batch 38.30 | loss  3.96 | ppl    52.41
-----------------------------------------------------------------------------------------
| end of epoch  12 | time: 117.47s | valid loss  4.75 | valid ppl   116.11
-----------------------------------------------------------------------------------------
| epoch  13 |   200/ 2983 batches | lr 5.00 | ms/batch 38.59 | loss  4.06 | ppl    57.86
| epoch  13 |   400/ 2983 batches | lr 5.00 | ms/batch 38.32 | loss  4.05 | ppl    57.35
| epoch  13 |   600/ 2983 batches | lr 5.00 | ms/batch 38.38 | loss  3.86 | ppl    47.65
| epoch  13 |   800/ 2983 batches | lr 5.00 | ms/batch 38.34 | loss  3.89 | ppl    48.75
| epoch  13 |  1000/ 2983 batches | lr 5.00 | ms/batch 38.20 | loss  3.90 | ppl    49.39
| epoch  13 |  1200/ 2983 batches | lr 5.00 | ms/batch 38.28 | loss  3.89 | ppl    49.14
| epoch  13 |  1400/ 2983 batches | lr 5.00 | ms/batch 38.34 | loss  3.90 | ppl    49.39
| epoch  13 |  1600/ 2983 batches | lr 5.00 | ms/batch 38.29 | loss  3.96 | ppl    52.52
| epoch  13 |  1800/ 2983 batches | lr 5.00 | ms/batch 39.18 | loss  3.84 | ppl    46.69
| epoch  13 |  2000/ 2983 batches | lr 5.00 | ms/batch 38.67 | loss  3.85 | ppl    47.23
| epoch  13 |  2200/ 2983 batches | lr 5.00 | ms/batch 38.45 | loss  3.71 | ppl    40.86
| epoch  13 |  2400/ 2983 batches | lr 5.00 | ms/batch 38.33 | loss  3.74 | ppl    42.07
| epoch  13 |  2600/ 2983 batches | lr 5.00 | ms/batch 38.35 | loss  3.74 | ppl    42.22
| epoch  13 |  2800/ 2983 batches | lr 5.00 | ms/batch 38.33 | loss  3.68 | ppl    39.75
-----------------------------------------------------------------------------------------
| end of epoch  13 | time: 117.22s | valid loss  4.69 | valid ppl   109.27
-----------------------------------------------------------------------------------------
| epoch  14 |   200/ 2983 batches | lr 5.00 | ms/batch 38.70 | loss  3.90 | ppl    49.43
| epoch  14 |   400/ 2983 batches | lr 5.00 | ms/batch 38.45 | loss  3.91 | ppl    49.86
| epoch  14 |   600/ 2983 batches | lr 5.00 | ms/batch 38.33 | loss  3.73 | ppl    41.60
| epoch  14 |   800/ 2983 batches | lr 5.00 | ms/batch 38.32 | loss  3.77 | ppl    43.18
| epoch  14 |  1000/ 2983 batches | lr 5.00 | ms/batch 38.34 | loss  3.79 | ppl    44.32
| epoch  14 |  1200/ 2983 batches | lr 5.00 | ms/batch 38.41 | loss  3.80 | ppl    44.68
| epoch  14 |  1400/ 2983 batches | lr 5.00 | ms/batch 38.42 | loss  3.80 | ppl    44.84
| epoch  14 |  1600/ 2983 batches | lr 5.00 | ms/batch 38.43 | loss  3.87 | ppl    48.10
| epoch  14 |  1800/ 2983 batches | lr 5.00 | ms/batch 38.43 | loss  3.76 | ppl    43.04
| epoch  14 |  2000/ 2983 batches | lr 5.00 | ms/batch 38.43 | loss  3.78 | ppl    43.81
| epoch  14 |  2200/ 2983 batches | lr 5.00 | ms/batch 38.38 | loss  3.65 | ppl    38.38
| epoch  14 |  2400/ 2983 batches | lr 5.00 | ms/batch 38.39 | loss  3.68 | ppl    39.71
| epoch  14 |  2600/ 2983 batches | lr 5.00 | ms/batch 38.38 | loss  3.69 | ppl    40.09
| epoch  14 |  2800/ 2983 batches | lr 5.00 | ms/batch 38.45 | loss  3.64 | ppl    37.98
-----------------------------------------------------------------------------------------
| end of epoch  14 | time: 117.23s | valid loss  4.69 | valid ppl   108.45
-----------------------------------------------------------------------------------------
| epoch  15 |   200/ 2983 batches | lr 5.00 | ms/batch 38.76 | loss  3.83 | ppl    46.22
| epoch  15 |   400/ 2983 batches | lr 5.00 | ms/batch 38.52 | loss  3.84 | ppl    46.70
| epoch  15 |   600/ 2983 batches | lr 5.00 | ms/batch 38.47 | loss  3.67 | ppl    39.45
| epoch  15 |   800/ 2983 batches | lr 5.00 | ms/batch 38.45 | loss  3.71 | ppl    40.79
| epoch  15 |  1000/ 2983 batches | lr 5.00 | ms/batch 38.30 | loss  3.73 | ppl    41.56
| epoch  15 |  1200/ 2983 batches | lr 5.00 | ms/batch 38.39 | loss  3.74 | ppl    42.31
| epoch  15 |  1400/ 2983 batches | lr 5.00 | ms/batch 38.40 | loss  3.76 | ppl    42.91
| epoch  15 |  1600/ 2983 batches | lr 5.00 | ms/batch 38.42 | loss  3.83 | ppl    45.86
| epoch  15 |  1800/ 2983 batches | lr 5.00 | ms/batch 38.49 | loss  3.71 | ppl    41.04
| epoch  15 |  2000/ 2983 batches | lr 5.00 | ms/batch 38.41 | loss  3.74 | ppl    41.99
| epoch  15 |  2200/ 2983 batches | lr 5.00 | ms/batch 38.51 | loss  3.60 | ppl    36.48
| epoch  15 |  2400/ 2983 batches | lr 5.00 | ms/batch 38.41 | loss  3.64 | ppl    38.11
| epoch  15 |  2600/ 2983 batches | lr 5.00 | ms/batch 38.35 | loss  3.65 | ppl    38.57
| epoch  15 |  2800/ 2983 batches | lr 5.00 | ms/batch 38.37 | loss  3.61 | ppl    36.93
-----------------------------------------------------------------------------------------
| end of epoch  15 | time: 117.34s | valid loss  4.69 | valid ppl   108.67
-----------------------------------------------------------------------------------------
| epoch  16 |   200/ 2983 batches | lr 1.25 | ms/batch 38.69 | loss  3.85 | ppl    46.84
| epoch  16 |   400/ 2983 batches | lr 1.25 | ms/batch 38.54 | loss  3.88 | ppl    48.58
| epoch  16 |   600/ 2983 batches | lr 1.25 | ms/batch 38.41 | loss  3.69 | ppl    39.89
| epoch  16 |   800/ 2983 batches | lr 1.25 | ms/batch 38.51 | loss  3.74 | ppl    42.17
| epoch  16 |  1000/ 2983 batches | lr 1.25 | ms/batch 38.64 | loss  3.72 | ppl    41.27
| epoch  16 |  1200/ 2983 batches | lr 1.25 | ms/batch 38.63 | loss  3.76 | ppl    42.84
| epoch  16 |  1400/ 2983 batches | lr 1.25 | ms/batch 38.57 | loss  3.76 | ppl    42.92
| epoch  16 |  1600/ 2983 batches | lr 1.25 | ms/batch 38.50 | loss  3.82 | ppl    45.70
| epoch  16 |  1800/ 2983 batches | lr 1.25 | ms/batch 39.07 | loss  3.70 | ppl    40.34
| epoch  16 |  2000/ 2983 batches | lr 1.25 | ms/batch 38.96 | loss  3.71 | ppl    40.93
| epoch  16 |  2200/ 2983 batches | lr 1.25 | ms/batch 39.17 | loss  3.58 | ppl    35.72
| epoch  16 |  2400/ 2983 batches | lr 1.25 | ms/batch 38.79 | loss  3.60 | ppl    36.62
| epoch  16 |  2600/ 2983 batches | lr 1.25 | ms/batch 38.92 | loss  3.62 | ppl    37.17
| epoch  16 |  2800/ 2983 batches | lr 1.25 | ms/batch 38.88 | loss  3.56 | ppl    35.09
-----------------------------------------------------------------------------------------
| end of epoch  16 | time: 118.18s | valid loss  4.67 | valid ppl   106.39
-----------------------------------------------------------------------------------------
| epoch  17 |   200/ 2983 batches | lr 1.25 | ms/batch 39.08 | loss  3.82 | ppl    45.53
| epoch  17 |   400/ 2983 batches | lr 1.25 | ms/batch 39.08 | loss  3.84 | ppl    46.33
| epoch  17 |   600/ 2983 batches | lr 1.25 | ms/batch 38.87 | loss  3.64 | ppl    37.94
| epoch  17 |   800/ 2983 batches | lr 1.25 | ms/batch 38.64 | loss  3.69 | ppl    40.20
| epoch  17 |  1000/ 2983 batches | lr 1.25 | ms/batch 38.80 | loss  3.68 | ppl    39.80
| epoch  17 |  1200/ 2983 batches | lr 1.25 | ms/batch 38.79 | loss  3.72 | ppl    41.28
| epoch  17 |  1400/ 2983 batches | lr 1.25 | ms/batch 38.42 | loss  3.72 | ppl    41.27
| epoch  17 |  1600/ 2983 batches | lr 1.25 | ms/batch 38.48 | loss  3.79 | ppl    44.17
| epoch  17 |  1800/ 2983 batches | lr 1.25 | ms/batch 38.32 | loss  3.67 | ppl    39.29
| epoch  17 |  2000/ 2983 batches | lr 1.25 | ms/batch 38.32 | loss  3.69 | ppl    39.94
| epoch  17 |  2200/ 2983 batches | lr 1.25 | ms/batch 38.29 | loss  3.55 | ppl    34.80
| epoch  17 |  2400/ 2983 batches | lr 1.25 | ms/batch 38.30 | loss  3.58 | ppl    35.85
| epoch  17 |  2600/ 2983 batches | lr 1.25 | ms/batch 38.28 | loss  3.60 | ppl    36.69
| epoch  17 |  2800/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.55 | ppl    34.77
-----------------------------------------------------------------------------------------
| end of epoch  17 | time: 117.70s | valid loss  4.67 | valid ppl   106.38
-----------------------------------------------------------------------------------------
| epoch  18 |   200/ 2983 batches | lr 1.25 | ms/batch 38.55 | loss  3.80 | ppl    44.52
| epoch  18 |   400/ 2983 batches | lr 1.25 | ms/batch 38.25 | loss  3.81 | ppl    45.07
| epoch  18 |   600/ 2983 batches | lr 1.25 | ms/batch 38.49 | loss  3.62 | ppl    37.22
| epoch  18 |   800/ 2983 batches | lr 1.25 | ms/batch 38.48 | loss  3.67 | ppl    39.17
| epoch  18 |  1000/ 2983 batches | lr 1.25 | ms/batch 38.30 | loss  3.66 | ppl    38.83
| epoch  18 |  1200/ 2983 batches | lr 1.25 | ms/batch 38.29 | loss  3.70 | ppl    40.35
| epoch  18 |  1400/ 2983 batches | lr 1.25 | ms/batch 38.34 | loss  3.71 | ppl    40.73
| epoch  18 |  1600/ 2983 batches | lr 1.25 | ms/batch 38.40 | loss  3.77 | ppl    43.55
| epoch  18 |  1800/ 2983 batches | lr 1.25 | ms/batch 38.33 | loss  3.65 | ppl    38.64
| epoch  18 |  2000/ 2983 batches | lr 1.25 | ms/batch 38.38 | loss  3.68 | ppl    39.50
| epoch  18 |  2200/ 2983 batches | lr 1.25 | ms/batch 38.43 | loss  3.54 | ppl    34.37
| epoch  18 |  2400/ 2983 batches | lr 1.25 | ms/batch 38.33 | loss  3.57 | ppl    35.55
| epoch  18 |  2600/ 2983 batches | lr 1.25 | ms/batch 38.34 | loss  3.59 | ppl    36.26
| epoch  18 |  2800/ 2983 batches | lr 1.25 | ms/batch 38.38 | loss  3.53 | ppl    34.28
-----------------------------------------------------------------------------------------
| end of epoch  18 | time: 117.18s | valid loss  4.67 | valid ppl   106.36
-----------------------------------------------------------------------------------------
| epoch  19 |   200/ 2983 batches | lr 1.25 | ms/batch 38.51 | loss  3.77 | ppl    43.48
| epoch  19 |   400/ 2983 batches | lr 1.25 | ms/batch 38.42 | loss  3.80 | ppl    44.54
| epoch  19 |   600/ 2983 batches | lr 1.25 | ms/batch 38.31 | loss  3.60 | ppl    36.42
| epoch  19 |   800/ 2983 batches | lr 1.25 | ms/batch 38.34 | loss  3.64 | ppl    38.25
| epoch  19 |  1000/ 2983 batches | lr 1.25 | ms/batch 38.51 | loss  3.64 | ppl    38.13
| epoch  19 |  1200/ 2983 batches | lr 1.25 | ms/batch 38.46 | loss  3.68 | ppl    39.61
| epoch  19 |  1400/ 2983 batches | lr 1.25 | ms/batch 38.55 | loss  3.69 | ppl    40.04
| epoch  19 |  1600/ 2983 batches | lr 1.25 | ms/batch 38.52 | loss  3.76 | ppl    42.81
| epoch  19 |  1800/ 2983 batches | lr 1.25 | ms/batch 38.35 | loss  3.64 | ppl    38.23
| epoch  19 |  2000/ 2983 batches | lr 1.25 | ms/batch 38.41 | loss  3.67 | ppl    39.07
| epoch  19 |  2200/ 2983 batches | lr 1.25 | ms/batch 38.35 | loss  3.53 | ppl    34.01
| epoch  19 |  2400/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.56 | ppl    35.14
| epoch  19 |  2600/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.58 | ppl    35.96
| epoch  19 |  2800/ 2983 batches | lr 1.25 | ms/batch 38.40 | loss  3.53 | ppl    33.99
-----------------------------------------------------------------------------------------
| end of epoch  19 | time: 117.28s | valid loss  4.67 | valid ppl   106.27
-----------------------------------------------------------------------------------------
| epoch  20 |   200/ 2983 batches | lr 1.25 | ms/batch 38.57 | loss  3.76 | ppl    42.83
| epoch  20 |   400/ 2983 batches | lr 1.25 | ms/batch 38.40 | loss  3.77 | ppl    43.58
| epoch  20 |   600/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.58 | ppl    35.94
| epoch  20 |   800/ 2983 batches | lr 1.25 | ms/batch 38.37 | loss  3.63 | ppl    37.73
| epoch  20 |  1000/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.63 | ppl    37.59
| epoch  20 |  1200/ 2983 batches | lr 1.25 | ms/batch 38.38 | loss  3.67 | ppl    39.06
| epoch  20 |  1400/ 2983 batches | lr 1.25 | ms/batch 38.42 | loss  3.68 | ppl    39.60
| epoch  20 |  1600/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.73 | ppl    41.86
| epoch  20 |  1800/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.63 | ppl    37.67
| epoch  20 |  2000/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.65 | ppl    38.42
| epoch  20 |  2200/ 2983 batches | lr 1.25 | ms/batch 38.35 | loss  3.52 | ppl    33.85
| epoch  20 |  2400/ 2983 batches | lr 1.25 | ms/batch 38.45 | loss  3.55 | ppl    34.70
| epoch  20 |  2600/ 2983 batches | lr 1.25 | ms/batch 38.40 | loss  3.57 | ppl    35.50
| epoch  20 |  2800/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.52 | ppl    33.80
-----------------------------------------------------------------------------------------
| end of epoch  20 | time: 117.23s | valid loss  4.66 | valid ppl   106.15
-----------------------------------------------------------------------------------------
| epoch  21 |   200/ 2983 batches | lr 1.25 | ms/batch 38.67 | loss  3.74 | ppl    42.02
| epoch  21 |   400/ 2983 batches | lr 1.25 | ms/batch 38.42 | loss  3.76 | ppl    43.01
| epoch  21 |   600/ 2983 batches | lr 1.25 | ms/batch 38.37 | loss  3.56 | ppl    35.20
| epoch  21 |   800/ 2983 batches | lr 1.25 | ms/batch 38.32 | loss  3.61 | ppl    37.07
| epoch  21 |  1000/ 2983 batches | lr 1.25 | ms/batch 38.36 | loss  3.61 | ppl    36.89
| epoch  21 |  1200/ 2983 batches | lr 1.25 | ms/batch 38.41 | loss  3.65 | ppl    38.37
| epoch  21 |  1400/ 2983 batches | lr 1.25 | ms/batch 38.40 | loss  3.67 | ppl    39.09
| epoch  21 |  1600/ 2983 batches | lr 1.25 | ms/batch 38.34 | loss  3.73 | ppl    41.75
| epoch  21 |  1800/ 2983 batches | lr 1.25 | ms/batch 38.36 | loss  3.61 | ppl    36.98
| epoch  21 |  2000/ 2983 batches | lr 1.25 | ms/batch 38.48 | loss  3.64 | ppl    38.00
| epoch  21 |  2200/ 2983 batches | lr 1.25 | ms/batch 38.39 | loss  3.50 | ppl    33.17
| epoch  21 |  2400/ 2983 batches | lr 1.25 | ms/batch 38.34 | loss  3.54 | ppl    34.40
| epoch  21 |  2600/ 2983 batches | lr 1.25 | ms/batch 38.52 | loss  3.56 | ppl    35.22
| epoch  21 |  2800/ 2983 batches | lr 1.25 | ms/batch 38.46 | loss  3.50 | ppl    33.26
-----------------------------------------------------------------------------------------
| end of epoch  21 | time: 117.24s | valid loss  4.67 | valid ppl   106.49
-----------------------------------------------------------------------------------------
| epoch  22 |   200/ 2983 batches | lr 0.31 | ms/batch 38.70 | loss  3.76 | ppl    42.92
| epoch  22 |   400/ 2983 batches | lr 0.31 | ms/batch 38.42 | loss  3.82 | ppl    45.57
| epoch  22 |   600/ 2983 batches | lr 0.31 | ms/batch 38.40 | loss  3.62 | ppl    37.15
| epoch  22 |   800/ 2983 batches | lr 0.31 | ms/batch 38.47 | loss  3.68 | ppl    39.62
| epoch  22 |  1000/ 2983 batches | lr 0.31 | ms/batch 38.31 | loss  3.67 | ppl    39.12
| epoch  22 |  1200/ 2983 batches | lr 0.31 | ms/batch 38.39 | loss  3.65 | ppl    38.29
| epoch  22 |  1400/ 2983 batches | lr 0.31 | ms/batch 38.41 | loss  3.69 | ppl    40.04
| epoch  22 |  1600/ 2983 batches | lr 0.31 | ms/batch 38.25 | loss  3.76 | ppl    42.87
| epoch  22 |  1800/ 2983 batches | lr 0.31 | ms/batch 38.33 | loss  3.65 | ppl    38.35
| epoch  22 |  2000/ 2983 batches | lr 0.31 | ms/batch 38.56 | loss  3.65 | ppl    38.30
| epoch  22 |  2200/ 2983 batches | lr 0.31 | ms/batch 38.37 | loss  3.51 | ppl    33.58
| epoch  22 |  2400/ 2983 batches | lr 0.31 | ms/batch 38.50 | loss  3.55 | ppl    34.68
| epoch  22 |  2600/ 2983 batches | lr 0.31 | ms/batch 38.33 | loss  3.58 | ppl    35.94
| epoch  22 |  2800/ 2983 batches | lr 0.31 | ms/batch 38.48 | loss  3.52 | ppl    33.74
-----------------------------------------------------------------------------------------
| end of epoch  22 | time: 117.23s | valid loss  4.64 | valid ppl   103.98
-----------------------------------------------------------------------------------------
| epoch  23 |   200/ 2983 batches | lr 0.31 | ms/batch 38.56 | loss  3.75 | ppl    42.54
| epoch  23 |   400/ 2983 batches | lr 0.31 | ms/batch 38.39 | loss  3.78 | ppl    43.78
| epoch  23 |   600/ 2983 batches | lr 0.31 | ms/batch 38.43 | loss  3.58 | ppl    35.82
| epoch  23 |   800/ 2983 batches | lr 0.31 | ms/batch 38.54 | loss  3.66 | ppl    38.77
| epoch  23 |  1000/ 2983 batches | lr 0.31 | ms/batch 38.45 | loss  3.65 | ppl    38.44
| epoch  23 |  1200/ 2983 batches | lr 0.31 | ms/batch 38.47 | loss  3.64 | ppl    38.03
| epoch  23 |  1400/ 2983 batches | lr 0.31 | ms/batch 38.36 | loss  3.67 | ppl    39.43
| epoch  23 |  1600/ 2983 batches | lr 0.31 | ms/batch 38.52 | loss  3.75 | ppl    42.69
| epoch  23 |  1800/ 2983 batches | lr 0.31 | ms/batch 38.37 | loss  3.63 | ppl    37.83
| epoch  23 |  2000/ 2983 batches | lr 0.31 | ms/batch 38.54 | loss  3.64 | ppl    38.08
| epoch  23 |  2200/ 2983 batches | lr 0.31 | ms/batch 38.47 | loss  3.51 | ppl    33.40
| epoch  23 |  2400/ 2983 batches | lr 0.31 | ms/batch 38.39 | loss  3.55 | ppl    34.73
| epoch  23 |  2600/ 2983 batches | lr 0.31 | ms/batch 38.43 | loss  3.57 | ppl    35.59
| epoch  23 |  2800/ 2983 batches | lr 0.31 | ms/batch 38.52 | loss  3.52 | ppl    33.68
-----------------------------------------------------------------------------------------
| end of epoch  23 | time: 117.34s | valid loss  4.64 | valid ppl   103.86
-----------------------------------------------------------------------------------------
| epoch  24 |   200/ 2983 batches | lr 0.31 | ms/batch 38.60 | loss  3.74 | ppl    42.09
| epoch  24 |   400/ 2983 batches | lr 0.31 | ms/batch 38.35 | loss  3.77 | ppl    43.56
| epoch  24 |   600/ 2983 batches | lr 0.31 | ms/batch 38.81 | loss  3.57 | ppl    35.54
| epoch  24 |   800/ 2983 batches | lr 0.31 | ms/batch 38.56 | loss  3.65 | ppl    38.42
| epoch  24 |  1000/ 2983 batches | lr 0.31 | ms/batch 38.57 | loss  3.64 | ppl    38.08
| epoch  24 |  1200/ 2983 batches | lr 0.31 | ms/batch 38.36 | loss  3.63 | ppl    37.85
| epoch  24 |  1400/ 2983 batches | lr 0.31 | ms/batch 38.36 | loss  3.67 | ppl    39.41
| epoch  24 |  1600/ 2983 batches | lr 0.31 | ms/batch 38.44 | loss  3.74 | ppl    42.30
| epoch  24 |  1800/ 2983 batches | lr 0.31 | ms/batch 38.39 | loss  3.63 | ppl    37.65
| epoch  24 |  2000/ 2983 batches | lr 0.31 | ms/batch 38.45 | loss  3.63 | ppl    37.70
| epoch  24 |  2200/ 2983 batches | lr 0.31 | ms/batch 38.54 | loss  3.51 | ppl    33.35
| epoch  24 |  2400/ 2983 batches | lr 0.31 | ms/batch 38.40 | loss  3.54 | ppl    34.53
| epoch  24 |  2600/ 2983 batches | lr 0.31 | ms/batch 38.51 | loss  3.57 | ppl    35.50
| epoch  24 |  2800/ 2983 batches | lr 0.31 | ms/batch 38.45 | loss  3.52 | ppl    33.65
-----------------------------------------------------------------------------------------
| end of epoch  24 | time: 117.44s | valid loss  4.64 | valid ppl   103.82
-----------------------------------------------------------------------------------------
| epoch  25 |   200/ 2983 batches | lr 0.31 | ms/batch 38.73 | loss  3.74 | ppl    42.00
| epoch  25 |   400/ 2983 batches | lr 0.31 | ms/batch 38.43 | loss  3.77 | ppl    43.17
| epoch  25 |   600/ 2983 batches | lr 0.31 | ms/batch 38.52 | loss  3.56 | ppl    35.15
| epoch  25 |   800/ 2983 batches | lr 0.31 | ms/batch 38.47 | loss  3.64 | ppl    38.17
| epoch  25 |  1000/ 2983 batches | lr 0.31 | ms/batch 38.46 | loss  3.64 | ppl    38.19
| epoch  25 |  1200/ 2983 batches | lr 0.31 | ms/batch 38.36 | loss  3.63 | ppl    37.77
| epoch  25 |  1400/ 2983 batches | lr 0.31 | ms/batch 38.40 | loss  3.66 | ppl    38.86
| epoch  25 |  1600/ 2983 batches | lr 0.31 | ms/batch 38.50 | loss  3.74 | ppl    42.20
| epoch  25 |  1800/ 2983 batches | lr 0.31 | ms/batch 38.39 | loss  3.62 | ppl    37.46
| epoch  25 |  2000/ 2983 batches | lr 0.31 | ms/batch 38.50 | loss  3.63 | ppl    37.70
| epoch  25 |  2200/ 2983 batches | lr 0.31 | ms/batch 38.42 | loss  3.50 | ppl    33.04
| epoch  25 |  2400/ 2983 batches | lr 0.31 | ms/batch 38.38 | loss  3.54 | ppl    34.46
| epoch  25 |  2600/ 2983 batches | lr 0.31 | ms/batch 38.98 | loss  3.57 | ppl    35.50
| epoch  25 |  2800/ 2983 batches | lr 0.31 | ms/batch 38.51 | loss  3.52 | ppl    33.69
-----------------------------------------------------------------------------------------
| end of epoch  25 | time: 117.55s | valid loss  4.64 | valid ppl   103.69
-----------------------------------------------------------------------------------------
| epoch  26 |   200/ 2983 batches | lr 0.31 | ms/batch 38.64 | loss  3.73 | ppl    41.54
| epoch  26 |   400/ 2983 batches | lr 0.31 | ms/batch 38.36 | loss  3.76 | ppl    43.01
| epoch  26 |   600/ 2983 batches | lr 0.31 | ms/batch 38.60 | loss  3.56 | ppl    35.11
| epoch  26 |   800/ 2983 batches | lr 0.31 | ms/batch 38.48 | loss  3.63 | ppl    37.86
| epoch  26 |  1000/ 2983 batches | lr 0.31 | ms/batch 38.40 | loss  3.63 | ppl    37.68
| epoch  26 |  1200/ 2983 batches | lr 0.31 | ms/batch 38.45 | loss  3.63 | ppl    37.53
| epoch  26 |  1400/ 2983 batches | lr 0.31 | ms/batch 38.52 | loss  3.66 | ppl    38.72
| epoch  26 |  1600/ 2983 batches | lr 0.31 | ms/batch 38.43 | loss  3.74 | ppl    41.99
| epoch  26 |  1800/ 2983 batches | lr 0.31 | ms/batch 38.46 | loss  3.62 | ppl    37.32
| epoch  26 |  2000/ 2983 batches | lr 0.31 | ms/batch 38.68 | loss  3.62 | ppl    37.51
| epoch  26 |  2200/ 2983 batches | lr 0.31 | ms/batch 38.94 | loss  3.50 | ppl    33.07
| epoch  26 |  2400/ 2983 batches | lr 0.31 | ms/batch 38.64 | loss  3.54 | ppl    34.38
| epoch  26 |  2600/ 2983 batches | lr 0.31 | ms/batch 38.64 | loss  3.57 | ppl    35.49
| epoch  26 |  2800/ 2983 batches | lr 0.31 | ms/batch 39.18 | loss  3.51 | ppl    33.58
-----------------------------------------------------------------------------------------
| end of epoch  26 | time: 117.87s | valid loss  4.64 | valid ppl   103.76
-----------------------------------------------------------------------------------------
| epoch  27 |   200/ 2983 batches | lr 0.08 | ms/batch 38.85 | loss  3.73 | ppl    41.86
| epoch  27 |   400/ 2983 batches | lr 0.08 | ms/batch 38.42 | loss  3.78 | ppl    43.83
| epoch  27 |   600/ 2983 batches | lr 0.08 | ms/batch 38.40 | loss  3.58 | ppl    35.97
| epoch  27 |   800/ 2983 batches | lr 0.08 | ms/batch 38.37 | loss  3.67 | ppl    39.28
| epoch  27 |  1000/ 2983 batches | lr 0.08 | ms/batch 38.40 | loss  3.69 | ppl    39.93
| epoch  27 |  1200/ 2983 batches | lr 0.08 | ms/batch 38.37 | loss  3.67 | ppl    39.19
| epoch  27 |  1400/ 2983 batches | lr 0.08 | ms/batch 38.45 | loss  3.68 | ppl    39.68
| epoch  27 |  1600/ 2983 batches | lr 0.08 | ms/batch 38.31 | loss  3.76 | ppl    42.80
| epoch  27 |  1800/ 2983 batches | lr 0.08 | ms/batch 38.44 | loss  3.65 | ppl    38.35
| epoch  27 |  2000/ 2983 batches | lr 0.08 | ms/batch 38.41 | loss  3.66 | ppl    38.73
| epoch  27 |  2200/ 2983 batches | lr 0.08 | ms/batch 38.44 | loss  3.51 | ppl    33.43
| epoch  27 |  2400/ 2983 batches | lr 0.08 | ms/batch 38.47 | loss  3.53 | ppl    34.01
| epoch  27 |  2600/ 2983 batches | lr 0.08 | ms/batch 38.39 | loss  3.56 | ppl    35.09
| epoch  27 |  2800/ 2983 batches | lr 0.08 | ms/batch 38.46 | loss  3.50 | ppl    33.20
-----------------------------------------------------------------------------------------
| end of epoch  27 | time: 117.32s | valid loss  4.63 | valid ppl   102.99
-----------------------------------------------------------------------------------------
| epoch  28 |   200/ 2983 batches | lr 0.08 | ms/batch 38.76 | loss  3.74 | ppl    41.91
| epoch  28 |   400/ 2983 batches | lr 0.08 | ms/batch 38.41 | loss  3.78 | ppl    43.84
| epoch  28 |   600/ 2983 batches | lr 0.08 | ms/batch 38.47 | loss  3.59 | ppl    36.18
| epoch  28 |   800/ 2983 batches | lr 0.08 | ms/batch 38.43 | loss  3.65 | ppl    38.56
| epoch  28 |  1000/ 2983 batches | lr 0.08 | ms/batch 38.23 | loss  3.67 | ppl    39.11
| epoch  28 |  1200/ 2983 batches | lr 0.08 | ms/batch 38.42 | loss  3.66 | ppl    38.72
| epoch  28 |  1400/ 2983 batches | lr 0.08 | ms/batch 38.35 | loss  3.67 | ppl    39.19
| epoch  28 |  1600/ 2983 batches | lr 0.08 | ms/batch 38.30 | loss  3.74 | ppl    42.20
| epoch  28 |  1800/ 2983 batches | lr 0.08 | ms/batch 38.53 | loss  3.64 | ppl    37.91
| epoch  28 |  2000/ 2983 batches | lr 0.08 | ms/batch 38.79 | loss  3.64 | ppl    38.25
| epoch  28 |  2200/ 2983 batches | lr 0.08 | ms/batch 38.61 | loss  3.51 | ppl    33.40
| epoch  28 |  2400/ 2983 batches | lr 0.08 | ms/batch 38.60 | loss  3.53 | ppl    34.21
| epoch  28 |  2600/ 2983 batches | lr 0.08 | ms/batch 38.89 | loss  3.56 | ppl    35.17
| epoch  28 |  2800/ 2983 batches | lr 0.08 | ms/batch 38.65 | loss  3.51 | ppl    33.51
-----------------------------------------------------------------------------------------
| end of epoch  28 | time: 117.60s | valid loss  4.63 | valid ppl   102.82
-----------------------------------------------------------------------------------------
| epoch  29 |   200/ 2983 batches | lr 0.08 | ms/batch 38.90 | loss  3.73 | ppl    41.79
| epoch  29 |   400/ 2983 batches | lr 0.08 | ms/batch 38.67 | loss  3.77 | ppl    43.44
| epoch  29 |   600/ 2983 batches | lr 0.08 | ms/batch 38.86 | loss  3.58 | ppl    35.81
| epoch  29 |   800/ 2983 batches | lr 0.08 | ms/batch 38.78 | loss  3.64 | ppl    38.15
| epoch  29 |  1000/ 2983 batches | lr 0.08 | ms/batch 38.27 | loss  3.66 | ppl    38.77
| epoch  29 |  1200/ 2983 batches | lr 0.08 | ms/batch 38.21 | loss  3.65 | ppl    38.47
| epoch  29 |  1400/ 2983 batches | lr 0.08 | ms/batch 38.31 | loss  3.66 | ppl    38.99
| epoch  29 |  1600/ 2983 batches | lr 0.08 | ms/batch 38.40 | loss  3.74 | ppl    42.24
| epoch  29 |  1800/ 2983 batches | lr 0.08 | ms/batch 38.28 | loss  3.64 | ppl    38.07
| epoch  29 |  2000/ 2983 batches | lr 0.08 | ms/batch 38.29 | loss  3.64 | ppl    38.15
| epoch  29 |  2200/ 2983 batches | lr 0.08 | ms/batch 38.41 | loss  3.50 | ppl    33.22
| epoch  29 |  2400/ 2983 batches | lr 0.08 | ms/batch 38.35 | loss  3.53 | ppl    34.16
| epoch  29 |  2600/ 2983 batches | lr 0.08 | ms/batch 38.52 | loss  3.56 | ppl    35.15
| epoch  29 |  2800/ 2983 batches | lr 0.08 | ms/batch 38.49 | loss  3.52 | ppl    33.63
-----------------------------------------------------------------------------------------
| end of epoch  29 | time: 117.41s | valid loss  4.63 | valid ppl   102.72
-----------------------------------------------------------------------------------------
| epoch  30 |   200/ 2983 batches | lr 0.08 | ms/batch 38.71 | loss  3.74 | ppl    42.04
| epoch  30 |   400/ 2983 batches | lr 0.08 | ms/batch 38.52 | loss  3.78 | ppl    43.62
| epoch  30 |   600/ 2983 batches | lr 0.08 | ms/batch 38.38 | loss  3.58 | ppl    35.78
| epoch  30 |   800/ 2983 batches | lr 0.08 | ms/batch 38.38 | loss  3.64 | ppl    38.16
| epoch  30 |  1000/ 2983 batches | lr 0.08 | ms/batch 38.52 | loss  3.66 | ppl    38.81
| epoch  30 |  1200/ 2983 batches | lr 0.08 | ms/batch 38.62 | loss  3.65 | ppl    38.31
| epoch  30 |  1400/ 2983 batches | lr 0.08 | ms/batch 38.47 | loss  3.67 | ppl    39.18
| epoch  30 |  1600/ 2983 batches | lr 0.08 | ms/batch 38.37 | loss  3.74 | ppl    41.99
| epoch  30 |  1800/ 2983 batches | lr 0.08 | ms/batch 38.38 | loss  3.63 | ppl    37.60
| epoch  30 |  2000/ 2983 batches | lr 0.08 | ms/batch 38.39 | loss  3.64 | ppl    37.98
| epoch  30 |  2200/ 2983 batches | lr 0.08 | ms/batch 38.36 | loss  3.51 | ppl    33.42
| epoch  30 |  2400/ 2983 batches | lr 0.08 | ms/batch 38.34 | loss  3.53 | ppl    34.07
| epoch  30 |  2600/ 2983 batches | lr 0.08 | ms/batch 38.28 | loss  3.56 | ppl    35.17
| epoch  30 |  2800/ 2983 batches | lr 0.08 | ms/batch 38.38 | loss  3.52 | ppl    33.63
-----------------------------------------------------------------------------------------
| end of epoch  30 | time: 117.24s | valid loss  4.63 | valid ppl   102.71
-----------------------------------------------------------------------------------------
| epoch  31 |   200/ 2983 batches | lr 0.08 | ms/batch 38.68 | loss  3.73 | ppl    41.78
| epoch  31 |   400/ 2983 batches | lr 0.08 | ms/batch 38.57 | loss  3.77 | ppl    43.43
| epoch  31 |   600/ 2983 batches | lr 0.08 | ms/batch 38.51 | loss  3.57 | ppl    35.58
| epoch  31 |   800/ 2983 batches | lr 0.08 | ms/batch 38.63 | loss  3.64 | ppl    38.11
| epoch  31 |  1000/ 2983 batches | lr 0.08 | ms/batch 38.55 | loss  3.66 | ppl    38.70
| epoch  31 |  1200/ 2983 batches | lr 0.08 | ms/batch 38.33 | loss  3.64 | ppl    38.16
| epoch  31 |  1400/ 2983 batches | lr 0.08 | ms/batch 38.44 | loss  3.66 | ppl    38.92
| epoch  31 |  1600/ 2983 batches | lr 0.08 | ms/batch 38.55 | loss  3.74 | ppl    42.00
| epoch  31 |  1800/ 2983 batches | lr 0.08 | ms/batch 38.50 | loss  3.63 | ppl    37.66
| epoch  31 |  2000/ 2983 batches | lr 0.08 | ms/batch 38.60 | loss  3.64 | ppl    38.00
| epoch  31 |  2200/ 2983 batches | lr 0.08 | ms/batch 38.41 | loss  3.51 | ppl    33.39
| epoch  31 |  2400/ 2983 batches | lr 0.08 | ms/batch 38.32 | loss  3.53 | ppl    34.21
| epoch  31 |  2600/ 2983 batches | lr 0.08 | ms/batch 38.59 | loss  3.56 | ppl    35.15
| epoch  31 |  2800/ 2983 batches | lr 0.08 | ms/batch 38.67 | loss  3.52 | ppl    33.67
-----------------------------------------------------------------------------------------
| end of epoch  31 | time: 117.61s | valid loss  4.63 | valid ppl   102.68
-----------------------------------------------------------------------------------------
| epoch  32 |   200/ 2983 batches | lr 0.08 | ms/batch 38.91 | loss  3.73 | ppl    41.78
| epoch  32 |   400/ 2983 batches | lr 0.08 | ms/batch 38.36 | loss  3.77 | ppl    43.33
| epoch  32 |   600/ 2983 batches | lr 0.08 | ms/batch 38.19 | loss  3.57 | ppl    35.68
| epoch  32 |   800/ 2983 batches | lr 0.08 | ms/batch 38.42 | loss  3.63 | ppl    37.86
| epoch  32 |  1000/ 2983 batches | lr 0.08 | ms/batch 38.54 | loss  3.65 | ppl    38.54
| epoch  32 |  1200/ 2983 batches | lr 0.08 | ms/batch 38.37 | loss  3.64 | ppl    38.23
| epoch  32 |  1400/ 2983 batches | lr 0.08 | ms/batch 38.49 | loss  3.66 | ppl    39.02
| epoch  32 |  1600/ 2983 batches | lr 0.08 | ms/batch 38.55 | loss  3.73 | ppl    41.88
| epoch  32 |  1800/ 2983 batches | lr 0.08 | ms/batch 38.41 | loss  3.62 | ppl    37.49
| epoch  32 |  2000/ 2983 batches | lr 0.08 | ms/batch 38.31 | loss  3.64 | ppl    38.04
| epoch  32 |  2200/ 2983 batches | lr 0.08 | ms/batch 38.32 | loss  3.51 | ppl    33.37
| epoch  32 |  2400/ 2983 batches | lr 0.08 | ms/batch 38.41 | loss  3.53 | ppl    34.09
| epoch  32 |  2600/ 2983 batches | lr 0.08 | ms/batch 38.40 | loss  3.56 | ppl    35.14
| epoch  32 |  2800/ 2983 batches | lr 0.08 | ms/batch 38.45 | loss  3.52 | ppl    33.63
-----------------------------------------------------------------------------------------
| end of epoch  32 | time: 117.28s | valid loss  4.63 | valid ppl   102.67
-----------------------------------------------------------------------------------------
| epoch  33 |   200/ 2983 batches | lr 0.08 | ms/batch 38.68 | loss  3.73 | ppl    41.76
| epoch  33 |   400/ 2983 batches | lr 0.08 | ms/batch 38.36 | loss  3.76 | ppl    43.14
| epoch  33 |   600/ 2983 batches | lr 0.08 | ms/batch 38.48 | loss  3.57 | ppl    35.41
| epoch  33 |   800/ 2983 batches | lr 0.08 | ms/batch 38.48 | loss  3.63 | ppl    37.71
| epoch  33 |  1000/ 2983 batches | lr 0.08 | ms/batch 38.42 | loss  3.65 | ppl    38.50
| epoch  33 |  1200/ 2983 batches | lr 0.08 | ms/batch 38.51 | loss  3.64 | ppl    38.06
| epoch  33 |  1400/ 2983 batches | lr 0.08 | ms/batch 38.44 | loss  3.66 | ppl    38.85
| epoch  33 |  1600/ 2983 batches | lr 0.08 | ms/batch 38.59 | loss  3.73 | ppl    41.71
| epoch  33 |  1800/ 2983 batches | lr 0.08 | ms/batch 38.48 | loss  3.63 | ppl    37.59
| epoch  33 |  2000/ 2983 batches | lr 0.08 | ms/batch 38.46 | loss  3.63 | ppl    37.64
| epoch  33 |  2200/ 2983 batches | lr 0.08 | ms/batch 38.54 | loss  3.51 | ppl    33.30
| epoch  33 |  2400/ 2983 batches | lr 0.08 | ms/batch 38.47 | loss  3.53 | ppl    34.14
| epoch  33 |  2600/ 2983 batches | lr 0.08 | ms/batch 38.43 | loss  3.56 | ppl    35.11
| epoch  33 |  2800/ 2983 batches | lr 0.08 | ms/batch 38.50 | loss  3.52 | ppl    33.77
-----------------------------------------------------------------------------------------
| end of epoch  33 | time: 117.40s | valid loss  4.63 | valid ppl   102.67
-----------------------------------------------------------------------------------------
| epoch  34 |   200/ 2983 batches | lr 0.02 | ms/batch 38.66 | loss  3.73 | ppl    41.59
| epoch  34 |   400/ 2983 batches | lr 0.02 | ms/batch 38.53 | loss  3.77 | ppl    43.30
| epoch  34 |   600/ 2983 batches | lr 0.02 | ms/batch 38.44 | loss  3.58 | ppl    35.89
| epoch  34 |   800/ 2983 batches | lr 0.02 | ms/batch 38.28 | loss  3.65 | ppl    38.39
| epoch  34 |  1000/ 2983 batches | lr 0.02 | ms/batch 38.36 | loss  3.66 | ppl    38.70
| epoch  34 |  1200/ 2983 batches | lr 0.02 | ms/batch 38.33 | loss  3.65 | ppl    38.59
| epoch  34 |  1400/ 2983 batches | lr 0.02 | ms/batch 38.30 | loss  3.67 | ppl    39.31
| epoch  34 |  1600/ 2983 batches | lr 0.02 | ms/batch 38.32 | loss  3.73 | ppl    41.88
| epoch  34 |  1800/ 2983 batches | lr 0.02 | ms/batch 38.43 | loss  3.62 | ppl    37.51
| epoch  34 |  2000/ 2983 batches | lr 0.02 | ms/batch 38.39 | loss  3.64 | ppl    38.11
| epoch  34 |  2200/ 2983 batches | lr 0.02 | ms/batch 38.25 | loss  3.51 | ppl    33.30
| epoch  34 |  2400/ 2983 batches | lr 0.02 | ms/batch 38.42 | loss  3.53 | ppl    33.99
| epoch  34 |  2600/ 2983 batches | lr 0.02 | ms/batch 38.61 | loss  3.55 | ppl    34.97
| epoch  34 |  2800/ 2983 batches | lr 0.02 | ms/batch 38.44 | loss  3.50 | ppl    33.26
-----------------------------------------------------------------------------------------
| end of epoch  34 | time: 117.20s | valid loss  4.63 | valid ppl   102.60
-----------------------------------------------------------------------------------------
| epoch  35 |   200/ 2983 batches | lr 0.02 | ms/batch 38.52 | loss  3.73 | ppl    41.77
| epoch  35 |   400/ 2983 batches | lr 0.02 | ms/batch 38.42 | loss  3.76 | ppl    43.11
| epoch  35 |   600/ 2983 batches | lr 0.02 | ms/batch 38.29 | loss  3.58 | ppl    36.00
| epoch  35 |   800/ 2983 batches | lr 0.02 | ms/batch 38.42 | loss  3.64 | ppl    38.02
| epoch  35 |  1000/ 2983 batches | lr 0.02 | ms/batch 38.42 | loss  3.66 | ppl    38.76
| epoch  35 |  1200/ 2983 batches | lr 0.02 | ms/batch 38.58 | loss  3.65 | ppl    38.59
| epoch  35 |  1400/ 2983 batches | lr 0.02 | ms/batch 38.83 | loss  3.67 | ppl    39.16
| epoch  35 |  1600/ 2983 batches | lr 0.02 | ms/batch 38.91 | loss  3.74 | ppl    41.92
| epoch  35 |  1800/ 2983 batches | lr 0.02 | ms/batch 38.63 | loss  3.63 | ppl    37.57
| epoch  35 |  2000/ 2983 batches | lr 0.02 | ms/batch 38.88 | loss  3.64 | ppl    38.06
| epoch  35 |  2200/ 2983 batches | lr 0.02 | ms/batch 38.57 | loss  3.51 | ppl    33.44
| epoch  35 |  2400/ 2983 batches | lr 0.02 | ms/batch 38.35 | loss  3.53 | ppl    34.09
| epoch  35 |  2600/ 2983 batches | lr 0.02 | ms/batch 38.46 | loss  3.55 | ppl    34.91
| epoch  35 |  2800/ 2983 batches | lr 0.02 | ms/batch 38.90 | loss  3.51 | ppl    33.43
-----------------------------------------------------------------------------------------
| end of epoch  35 | time: 117.83s | valid loss  4.63 | valid ppl   102.55
-----------------------------------------------------------------------------------------
| epoch  36 |   200/ 2983 batches | lr 0.02 | ms/batch 38.81 | loss  3.73 | ppl    41.75
| epoch  36 |   400/ 2983 batches | lr 0.02 | ms/batch 38.40 | loss  3.77 | ppl    43.41
| epoch  36 |   600/ 2983 batches | lr 0.02 | ms/batch 38.41 | loss  3.58 | ppl    35.97
| epoch  36 |   800/ 2983 batches | lr 0.02 | ms/batch 38.80 | loss  3.64 | ppl    38.26
| epoch  36 |  1000/ 2983 batches | lr 0.02 | ms/batch 39.15 | loss  3.66 | ppl    38.68
| epoch  36 |  1200/ 2983 batches | lr 0.02 | ms/batch 38.97 | loss  3.65 | ppl    38.44
| epoch  36 |  1400/ 2983 batches | lr 0.02 | ms/batch 38.76 | loss  3.67 | ppl    39.13
| epoch  36 |  1600/ 2983 batches | lr 0.02 | ms/batch 38.70 | loss  3.74 | ppl    41.93
| epoch  36 |  1800/ 2983 batches | lr 0.02 | ms/batch 38.75 | loss  3.63 | ppl    37.57
| epoch  36 |  2000/ 2983 batches | lr 0.02 | ms/batch 38.78 | loss  3.64 | ppl    37.93
| epoch  36 |  2200/ 2983 batches | lr 0.02 | ms/batch 38.94 | loss  3.51 | ppl    33.31
| epoch  36 |  2400/ 2983 batches | lr 0.02 | ms/batch 39.04 | loss  3.52 | ppl    33.86
| epoch  36 |  2600/ 2983 batches | lr 0.02 | ms/batch 39.02 | loss  3.56 | ppl    35.09
| epoch  36 |  2800/ 2983 batches | lr 0.02 | ms/batch 38.84 | loss  3.51 | ppl    33.61
-----------------------------------------------------------------------------------------
| end of epoch  36 | time: 118.40s | valid loss  4.63 | valid ppl   102.52
-----------------------------------------------------------------------------------------
| epoch  37 |   200/ 2983 batches | lr 0.02 | ms/batch 39.01 | loss  3.73 | ppl    41.68
| epoch  37 |   400/ 2983 batches | lr 0.02 | ms/batch 38.70 | loss  3.77 | ppl    43.36
| epoch  37 |   600/ 2983 batches | lr 0.02 | ms/batch 39.10 | loss  3.58 | ppl    35.93
| epoch  37 |   800/ 2983 batches | lr 0.02 | ms/batch 39.06 | loss  3.64 | ppl    38.27
| epoch  37 |  1000/ 2983 batches | lr 0.02 | ms/batch 38.95 | loss  3.66 | ppl    38.72
| epoch  37 |  1200/ 2983 batches | lr 0.02 | ms/batch 38.42 | loss  3.65 | ppl    38.38
| epoch  37 |  1400/ 2983 batches | lr 0.02 | ms/batch 38.46 | loss  3.66 | ppl    38.84
| epoch  37 |  1600/ 2983 batches | lr 0.02 | ms/batch 38.41 | loss  3.74 | ppl    41.89
| epoch  37 |  1800/ 2983 batches | lr 0.02 | ms/batch 38.81 | loss  3.62 | ppl    37.34
| epoch  37 |  2000/ 2983 batches | lr 0.02 | ms/batch 38.35 | loss  3.64 | ppl    37.92
| epoch  37 |  2200/ 2983 batches | lr 0.02 | ms/batch 38.48 | loss  3.50 | ppl    33.22
| epoch  37 |  2400/ 2983 batches | lr 0.02 | ms/batch 38.56 | loss  3.53 | ppl    33.98
| epoch  37 |  2600/ 2983 batches | lr 0.02 | ms/batch 38.38 | loss  3.56 | ppl    35.10
| epoch  37 |  2800/ 2983 batches | lr 0.02 | ms/batch 38.45 | loss  3.51 | ppl    33.33
-----------------------------------------------------------------------------------------
| end of epoch  37 | time: 117.88s | valid loss  4.63 | valid ppl   102.50
-----------------------------------------------------------------------------------------
| epoch  38 |   200/ 2983 batches | lr 0.02 | ms/batch 38.59 | loss  3.73 | ppl    41.85
| epoch  38 |   400/ 2983 batches | lr 0.02 | ms/batch 38.35 | loss  3.76 | ppl    43.08
| epoch  38 |   600/ 2983 batches | lr 0.02 | ms/batch 38.39 | loss  3.58 | ppl    35.92
| epoch  38 |   800/ 2983 batches | lr 0.02 | ms/batch 38.50 | loss  3.64 | ppl    38.15
| epoch  38 |  1000/ 2983 batches | lr 0.02 | ms/batch 38.52 | loss  3.65 | ppl    38.55
| epoch  38 |  1200/ 2983 batches | lr 0.02 | ms/batch 38.89 | loss  3.64 | ppl    38.09
| epoch  38 |  1400/ 2983 batches | lr 0.02 | ms/batch 38.45 | loss  3.67 | ppl    39.06
| epoch  38 |  1600/ 2983 batches | lr 0.02 | ms/batch 38.50 | loss  3.74 | ppl    41.99
| epoch  38 |  1800/ 2983 batches | lr 0.02 | ms/batch 38.44 | loss  3.63 | ppl    37.62
| epoch  38 |  2000/ 2983 batches | lr 0.02 | ms/batch 38.36 | loss  3.64 | ppl    38.08
| epoch  38 |  2200/ 2983 batches | lr 0.02 | ms/batch 38.32 | loss  3.50 | ppl    33.17
| epoch  38 |  2400/ 2983 batches | lr 0.02 | ms/batch 38.37 | loss  3.53 | ppl    34.13
| epoch  38 |  2600/ 2983 batches | lr 0.02 | ms/batch 38.38 | loss  3.56 | ppl    35.23
| epoch  38 |  2800/ 2983 batches | lr 0.02 | ms/batch 38.25 | loss  3.51 | ppl    33.55
-----------------------------------------------------------------------------------------
| end of epoch  38 | time: 117.31s | valid loss  4.63 | valid ppl   102.48
-----------------------------------------------------------------------------------------
| epoch  39 |   200/ 2983 batches | lr 0.02 | ms/batch 38.57 | loss  3.73 | ppl    41.74
| epoch  39 |   400/ 2983 batches | lr 0.02 | ms/batch 38.42 | loss  3.76 | ppl    43.14
| epoch  39 |   600/ 2983 batches | lr 0.02 | ms/batch 38.39 | loss  3.58 | ppl    35.79
| epoch  39 |   800/ 2983 batches | lr 0.02 | ms/batch 38.39 | loss  3.64 | ppl    38.11
| epoch  39 |  1000/ 2983 batches | lr 0.02 | ms/batch 38.33 | loss  3.65 | ppl    38.56
| epoch  39 |  1200/ 2983 batches | lr 0.02 | ms/batch 38.43 | loss  3.64 | ppl    38.03
| epoch  39 |  1400/ 2983 batches | lr 0.02 | ms/batch 38.36 | loss  3.66 | ppl    38.95
| epoch  39 |  1600/ 2983 batches | lr 0.02 | ms/batch 38.30 | loss  3.73 | ppl    41.71
| epoch  39 |  1800/ 2983 batches | lr 0.02 | ms/batch 38.46 | loss  3.62 | ppl    37.51
| epoch  39 |  2000/ 2983 batches | lr 0.02 | ms/batch 38.43 | loss  3.64 | ppl    38.01
| epoch  39 |  2200/ 2983 batches | lr 0.02 | ms/batch 38.37 | loss  3.50 | ppl    33.15
| epoch  39 |  2400/ 2983 batches | lr 0.02 | ms/batch 38.47 | loss  3.53 | ppl    34.07
| epoch  39 |  2600/ 2983 batches | lr 0.02 | ms/batch 38.45 | loss  3.56 | ppl    35.06
| epoch  39 |  2800/ 2983 batches | lr 0.02 | ms/batch 38.37 | loss  3.51 | ppl    33.48
-----------------------------------------------------------------------------------------
| end of epoch  39 | time: 117.18s | valid loss  4.63 | valid ppl   102.47
-----------------------------------------------------------------------------------------
| epoch  40 |   200/ 2983 batches | lr 0.02 | ms/batch 38.69 | loss  3.73 | ppl    41.61
| epoch  40 |   400/ 2983 batches | lr 0.02 | ms/batch 38.45 | loss  3.76 | ppl    43.07
| epoch  40 |   600/ 2983 batches | lr 0.02 | ms/batch 38.71 | loss  3.57 | ppl    35.64
| epoch  40 |   800/ 2983 batches | lr 0.02 | ms/batch 38.69 | loss  3.64 | ppl    38.05
| epoch  40 |  1000/ 2983 batches | lr 0.02 | ms/batch 39.55 | loss  3.64 | ppl    38.25
| epoch  40 |  1200/ 2983 batches | lr 0.02 | ms/batch 39.65 | loss  3.65 | ppl    38.42
| epoch  40 |  1400/ 2983 batches | lr 0.02 | ms/batch 39.23 | loss  3.67 | ppl    39.14
| epoch  40 |  1600/ 2983 batches | lr 0.02 | ms/batch 39.26 | loss  3.74 | ppl    41.92
| epoch  40 |  1800/ 2983 batches | lr 0.02 | ms/batch 39.22 | loss  3.63 | ppl    37.60
| epoch  40 |  2000/ 2983 batches | lr 0.02 | ms/batch 38.86 | loss  3.63 | ppl    37.70
| epoch  40 |  2200/ 2983 batches | lr 0.02 | ms/batch 38.80 | loss  3.50 | ppl    33.17
| epoch  40 |  2400/ 2983 batches | lr 0.02 | ms/batch 39.11 | loss  3.53 | ppl    34.16
| epoch  40 |  2600/ 2983 batches | lr 0.02 | ms/batch 39.10 | loss  3.56 | ppl    35.00
| epoch  40 |  2800/ 2983 batches | lr 0.02 | ms/batch 39.03 | loss  3.52 | ppl    33.68
-----------------------------------------------------------------------------------------
| end of epoch  40 | time: 119.01s | valid loss  4.63 | valid ppl   102.46
-----------------------------------------------------------------------------------------
=========================================================================================
| End of training | test loss  4.58 | test ppl    97.34
=========================================================================================
```

</details>
