### PR TITLE
add --device for vae

### DIFF
--- a/vae/README.md
+++ b/vae/README.md
@@ -12,10 +12,11 @@ The main.py script accepts the following arguments:
 
 ```bash
 optional arguments:
-  --batch-size		input batch size for training (default: 128)
-  --epochs		number of epochs to train (default: 10)
-  --no-cuda		enables CUDA training
-  --mps         enables GPU on macOS
-  --seed		random seed (default: 1)
-  --log-interval	how many batches to wait before logging training status
+  --batch-size N        input batch size for training (default: 128)
+  --epochs EPOCHS       number of epochs to train (default: 10)
+  --no-cuda             disables CUDA training
+  --no-mps              disables macOS GPU training
+  --device DEVICE       backend name
+  --seed SEED           random seed (default: 1)
+  --log-interval N      how many batches to wait before logging training status
 ```

--- a/vae/main.py
+++ b/vae/main.py
@@ -17,6 +17,8 @@ parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
 parser.add_argument('--no-mps', action='store_true', default=False,
                         help='disables macOS GPU training')
+parser.add_argument('--device', type=str, default='cpu',
+                    help='backend device')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
                     help='random seed (default: 1)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
@@ -32,7 +34,7 @@ if args.cuda:
 elif use_mps:
     device = torch.device("mps")
 else:
-    device = torch.device("cpu")
+    device = torch.device(args.device)
 
 kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
 train_loader = torch.utils.data.DataLoader(


### PR DESCRIPTION
Command:

```bash
$ python main.py --device npu
```

Log snippet:

```
====> Epoch: 9 Average loss: 106.4775
====> Test set loss: 106.0674
Train Epoch: 10 [0/60000 (0%)]	Loss: 103.728432
Train Epoch: 10 [1280/60000 (2%)]	Loss: 106.395348
Train Epoch: 10 [2560/60000 (4%)]	Loss: 105.388290
Train Epoch: 10 [3840/60000 (6%)]	Loss: 106.115608
Train Epoch: 10 [5120/60000 (9%)]	Loss: 106.691666
Train Epoch: 10 [6400/60000 (11%)]	Loss: 106.975655
Train Epoch: 10 [7680/60000 (13%)]	Loss: 105.457291
Train Epoch: 10 [8960/60000 (15%)]	Loss: 105.918594
Train Epoch: 10 [10240/60000 (17%)]	Loss: 108.195404
Train Epoch: 10 [11520/60000 (19%)]	Loss: 103.411369
Train Epoch: 10 [12800/60000 (21%)]	Loss: 104.274170
Train Epoch: 10 [14080/60000 (23%)]	Loss: 106.320824
Train Epoch: 10 [15360/60000 (26%)]	Loss: 105.991592
Train Epoch: 10 [16640/60000 (28%)]	Loss: 108.397949
Train Epoch: 10 [17920/60000 (30%)]	Loss: 106.172379
Train Epoch: 10 [19200/60000 (32%)]	Loss: 106.414986
Train Epoch: 10 [20480/60000 (34%)]	Loss: 104.865807
Train Epoch: 10 [21760/60000 (36%)]	Loss: 104.453087
Train Epoch: 10 [23040/60000 (38%)]	Loss: 106.033783
Train Epoch: 10 [24320/60000 (41%)]	Loss: 105.129906
Train Epoch: 10 [25600/60000 (43%)]	Loss: 105.693954
Train Epoch: 10 [26880/60000 (45%)]	Loss: 102.869789
Train Epoch: 10 [28160/60000 (47%)]	Loss: 108.188965
Train Epoch: 10 [29440/60000 (49%)]	Loss: 107.724869
Train Epoch: 10 [30720/60000 (51%)]	Loss: 108.226868
Train Epoch: 10 [32000/60000 (53%)]	Loss: 107.527931
Train Epoch: 10 [33280/60000 (55%)]	Loss: 103.218681
Train Epoch: 10 [34560/60000 (58%)]	Loss: 108.287979
Train Epoch: 10 [35840/60000 (60%)]	Loss: 107.876060
Train Epoch: 10 [37120/60000 (62%)]	Loss: 106.314049
Train Epoch: 10 [38400/60000 (64%)]	Loss: 108.712723
Train Epoch: 10 [39680/60000 (66%)]	Loss: 106.245323
Train Epoch: 10 [40960/60000 (68%)]	Loss: 106.572289
Train Epoch: 10 [42240/60000 (70%)]	Loss: 107.665848
Train Epoch: 10 [43520/60000 (72%)]	Loss: 104.337692
Train Epoch: 10 [44800/60000 (75%)]	Loss: 108.312622
Train Epoch: 10 [46080/60000 (77%)]	Loss: 105.260063
Train Epoch: 10 [47360/60000 (79%)]	Loss: 107.999985
Train Epoch: 10 [48640/60000 (81%)]	Loss: 102.944756
Train Epoch: 10 [49920/60000 (83%)]	Loss: 107.691856
Train Epoch: 10 [51200/60000 (85%)]	Loss: 105.387268
Train Epoch: 10 [52480/60000 (87%)]	Loss: 106.625946
Train Epoch: 10 [53760/60000 (90%)]	Loss: 105.363693
Train Epoch: 10 [55040/60000 (92%)]	Loss: 106.690437
Train Epoch: 10 [56320/60000 (94%)]	Loss: 109.625511
Train Epoch: 10 [57600/60000 (96%)]	Loss: 112.336594
Train Epoch: 10 [58880/60000 (98%)]	Loss: 107.636566
====> Epoch: 10 Average loss: 106.1004
====> Test set loss: 105.5604
```

<details>
<summary>Details</summary>

```
root@3dfeb58e2e6e:~/pytorch-examples/vae# python main.py --device npu
[W919 08:22:51.434891860 OperatorEntry.cpp:155] Warning: Warning only once for all operators,  other operators may also be overridden.
  Overriding a previously registered kernel for the same operator and the same dispatch key
  operator: aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
    registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
  dispatch key: CPU
  previous kernel: registered at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:497
       new kernel: registered at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:100 (function operator())
Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
Failed to download (trying next):
HTTP Error 403: Forbidden

Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz to ../data/MNIST/raw/train-images-idx3-ubyte.gz
100%|██████████████████████████████████████████████████████████████████████████████| 9.91M/9.91M [02:19<00:00, 71.3kB/s]
Extracting ../data/MNIST/raw/train-images-idx3-ubyte.gz to ../data/MNIST/raw

Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz
Failed to download (trying next):
HTTP Error 403: Forbidden

Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz to ../data/MNIST/raw/train-labels-idx1-ubyte.gz
100%|███████████████████████████████████████████████████████████████████████████████| 28.9k/28.9k [00:00<00:00, 120kB/s]
Extracting ../data/MNIST/raw/train-labels-idx1-ubyte.gz to ../data/MNIST/raw

Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz
Failed to download (trying next):
HTTP Error 403: Forbidden

Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz to ../data/MNIST/raw/t10k-images-idx3-ubyte.gz
100%|███████████████████████████████████████████████████████████████████████████████| 1.65M/1.65M [00:01<00:00, 863kB/s]
Extracting ../data/MNIST/raw/t10k-images-idx3-ubyte.gz to ../data/MNIST/raw

Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
Failed to download (trying next):
HTTP Error 403: Forbidden

Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz to ../data/MNIST/raw/t10k-labels-idx1-ubyte.gz
100%|██████████████████████████████████████████████████████████████████████████████| 4.54k/4.54k [00:00<00:00, 9.71MB/s]
Extracting ../data/MNIST/raw/t10k-labels-idx1-ubyte.gz to ../data/MNIST/raw

Train Epoch: 1 [0/60000 (0%)]	Loss: 550.500671
Train Epoch: 1 [1280/60000 (2%)]	Loss: 309.280701
Train Epoch: 1 [2560/60000 (4%)]	Loss: 239.885056
Train Epoch: 1 [3840/60000 (6%)]	Loss: 218.475220
Train Epoch: 1 [5120/60000 (9%)]	Loss: 213.141479
Train Epoch: 1 [6400/60000 (11%)]	Loss: 207.243073
Train Epoch: 1 [7680/60000 (13%)]	Loss: 204.075134
Train Epoch: 1 [8960/60000 (15%)]	Loss: 193.696854
Train Epoch: 1 [10240/60000 (17%)]	Loss: 192.808090
Train Epoch: 1 [11520/60000 (19%)]	Loss: 191.212357
Train Epoch: 1 [12800/60000 (21%)]	Loss: 180.928787
Train Epoch: 1 [14080/60000 (23%)]	Loss: 176.691757
Train Epoch: 1 [15360/60000 (26%)]	Loss: 186.764221
Train Epoch: 1 [16640/60000 (28%)]	Loss: 169.978867
Train Epoch: 1 [17920/60000 (30%)]	Loss: 167.858002
Train Epoch: 1 [19200/60000 (32%)]	Loss: 165.005066
Train Epoch: 1 [20480/60000 (34%)]	Loss: 162.604370
Train Epoch: 1 [21760/60000 (36%)]	Loss: 152.621506
Train Epoch: 1 [23040/60000 (38%)]	Loss: 158.064590
Train Epoch: 1 [24320/60000 (41%)]	Loss: 154.142120
Train Epoch: 1 [25600/60000 (43%)]	Loss: 155.768372
Train Epoch: 1 [26880/60000 (45%)]	Loss: 150.027084
Train Epoch: 1 [28160/60000 (47%)]	Loss: 153.693512
Train Epoch: 1 [29440/60000 (49%)]	Loss: 145.411392
Train Epoch: 1 [30720/60000 (51%)]	Loss: 141.324615
Train Epoch: 1 [32000/60000 (53%)]	Loss: 145.196335
Train Epoch: 1 [33280/60000 (55%)]	Loss: 145.452545
Train Epoch: 1 [34560/60000 (58%)]	Loss: 145.685059
Train Epoch: 1 [35840/60000 (60%)]	Loss: 138.029785
Train Epoch: 1 [37120/60000 (62%)]	Loss: 142.990143
Train Epoch: 1 [38400/60000 (64%)]	Loss: 140.297821
Train Epoch: 1 [39680/60000 (66%)]	Loss: 134.974396
Train Epoch: 1 [40960/60000 (68%)]	Loss: 143.168518
Train Epoch: 1 [42240/60000 (70%)]	Loss: 142.442490
Train Epoch: 1 [43520/60000 (72%)]	Loss: 140.820801
Train Epoch: 1 [44800/60000 (75%)]	Loss: 136.097107
Train Epoch: 1 [46080/60000 (77%)]	Loss: 141.083237
Train Epoch: 1 [47360/60000 (79%)]	Loss: 133.220230
Train Epoch: 1 [48640/60000 (81%)]	Loss: 132.829163
Train Epoch: 1 [49920/60000 (83%)]	Loss: 131.829926
Train Epoch: 1 [51200/60000 (85%)]	Loss: 130.909195
Train Epoch: 1 [52480/60000 (87%)]	Loss: 130.307419
Train Epoch: 1 [53760/60000 (90%)]	Loss: 132.038177
Train Epoch: 1 [55040/60000 (92%)]	Loss: 126.977379
Train Epoch: 1 [56320/60000 (94%)]	Loss: 137.966095
Train Epoch: 1 [57600/60000 (96%)]	Loss: 129.606339
Train Epoch: 1 [58880/60000 (98%)]	Loss: 132.342148
====> Epoch: 1 Average loss: 164.9652
====> Test set loss: 127.5772
Train Epoch: 2 [0/60000 (0%)]	Loss: 123.623077
Train Epoch: 2 [1280/60000 (2%)]	Loss: 123.116989
Train Epoch: 2 [2560/60000 (4%)]	Loss: 126.204323
Train Epoch: 2 [3840/60000 (6%)]	Loss: 130.888504
Train Epoch: 2 [5120/60000 (9%)]	Loss: 128.937393
Train Epoch: 2 [6400/60000 (11%)]	Loss: 131.505920
Train Epoch: 2 [7680/60000 (13%)]	Loss: 127.481842
Train Epoch: 2 [8960/60000 (15%)]	Loss: 125.359955
Train Epoch: 2 [10240/60000 (17%)]	Loss: 128.278000
Train Epoch: 2 [11520/60000 (19%)]	Loss: 123.799652
Train Epoch: 2 [12800/60000 (21%)]	Loss: 125.409271
Train Epoch: 2 [14080/60000 (23%)]	Loss: 122.017281
Train Epoch: 2 [15360/60000 (26%)]	Loss: 127.898987
Train Epoch: 2 [16640/60000 (28%)]	Loss: 122.736115
Train Epoch: 2 [17920/60000 (30%)]	Loss: 125.402519
Train Epoch: 2 [19200/60000 (32%)]	Loss: 124.170876
Train Epoch: 2 [20480/60000 (34%)]	Loss: 123.900841
Train Epoch: 2 [21760/60000 (36%)]	Loss: 120.142334
Train Epoch: 2 [23040/60000 (38%)]	Loss: 121.794243
Train Epoch: 2 [24320/60000 (41%)]	Loss: 120.489601
Train Epoch: 2 [25600/60000 (43%)]	Loss: 120.181702
Train Epoch: 2 [26880/60000 (45%)]	Loss: 116.283905
Train Epoch: 2 [28160/60000 (47%)]	Loss: 120.807693
Train Epoch: 2 [29440/60000 (49%)]	Loss: 121.248383
Train Epoch: 2 [30720/60000 (51%)]	Loss: 114.279678
Train Epoch: 2 [32000/60000 (53%)]	Loss: 120.799538
Train Epoch: 2 [33280/60000 (55%)]	Loss: 117.154831
Train Epoch: 2 [34560/60000 (58%)]	Loss: 120.311676
Train Epoch: 2 [35840/60000 (60%)]	Loss: 120.941895
Train Epoch: 2 [37120/60000 (62%)]	Loss: 121.215218
Train Epoch: 2 [38400/60000 (64%)]	Loss: 117.823120
Train Epoch: 2 [39680/60000 (66%)]	Loss: 117.600960
Train Epoch: 2 [40960/60000 (68%)]	Loss: 120.444641
Train Epoch: 2 [42240/60000 (70%)]	Loss: 122.594131
Train Epoch: 2 [43520/60000 (72%)]	Loss: 116.567024
Train Epoch: 2 [44800/60000 (75%)]	Loss: 121.538422
Train Epoch: 2 [46080/60000 (77%)]	Loss: 122.317612
Train Epoch: 2 [47360/60000 (79%)]	Loss: 117.161186
Train Epoch: 2 [48640/60000 (81%)]	Loss: 120.473145
Train Epoch: 2 [49920/60000 (83%)]	Loss: 114.441711
Train Epoch: 2 [51200/60000 (85%)]	Loss: 118.039917
Train Epoch: 2 [52480/60000 (87%)]	Loss: 116.336716
Train Epoch: 2 [53760/60000 (90%)]	Loss: 117.065163
Train Epoch: 2 [55040/60000 (92%)]	Loss: 116.314110
Train Epoch: 2 [56320/60000 (94%)]	Loss: 117.245483
Train Epoch: 2 [57600/60000 (96%)]	Loss: 117.078964
Train Epoch: 2 [58880/60000 (98%)]	Loss: 115.916008
====> Epoch: 2 Average loss: 121.5571
====> Test set loss: 116.1041
Train Epoch: 3 [0/60000 (0%)]	Loss: 121.088966
Train Epoch: 3 [1280/60000 (2%)]	Loss: 116.193939
Train Epoch: 3 [2560/60000 (4%)]	Loss: 117.186562
Train Epoch: 3 [3840/60000 (6%)]	Loss: 119.284752
Train Epoch: 3 [5120/60000 (9%)]	Loss: 118.693466
Train Epoch: 3 [6400/60000 (11%)]	Loss: 115.982765
Train Epoch: 3 [7680/60000 (13%)]	Loss: 114.696381
Train Epoch: 3 [8960/60000 (15%)]	Loss: 117.441185
Train Epoch: 3 [10240/60000 (17%)]	Loss: 115.470337
Train Epoch: 3 [11520/60000 (19%)]	Loss: 115.474602
Train Epoch: 3 [12800/60000 (21%)]	Loss: 115.810547
Train Epoch: 3 [14080/60000 (23%)]	Loss: 121.329430
Train Epoch: 3 [15360/60000 (26%)]	Loss: 116.599869
Train Epoch: 3 [16640/60000 (28%)]	Loss: 114.428352
Train Epoch: 3 [17920/60000 (30%)]	Loss: 118.292274
Train Epoch: 3 [19200/60000 (32%)]	Loss: 111.898537
Train Epoch: 3 [20480/60000 (34%)]	Loss: 115.756859
Train Epoch: 3 [21760/60000 (36%)]	Loss: 107.740005
Train Epoch: 3 [23040/60000 (38%)]	Loss: 114.344772
Train Epoch: 3 [24320/60000 (41%)]	Loss: 115.096458
Train Epoch: 3 [25600/60000 (43%)]	Loss: 113.665520
Train Epoch: 3 [26880/60000 (45%)]	Loss: 113.462662
Train Epoch: 3 [28160/60000 (47%)]	Loss: 112.430862
Train Epoch: 3 [29440/60000 (49%)]	Loss: 116.711243
Train Epoch: 3 [30720/60000 (51%)]	Loss: 112.388626
Train Epoch: 3 [32000/60000 (53%)]	Loss: 111.001884
Train Epoch: 3 [33280/60000 (55%)]	Loss: 115.757156
Train Epoch: 3 [34560/60000 (58%)]	Loss: 112.623383
Train Epoch: 3 [35840/60000 (60%)]	Loss: 114.809402
Train Epoch: 3 [37120/60000 (62%)]	Loss: 117.064018
Train Epoch: 3 [38400/60000 (64%)]	Loss: 114.198860
Train Epoch: 3 [39680/60000 (66%)]	Loss: 109.444962
Train Epoch: 3 [40960/60000 (68%)]	Loss: 111.619690
Train Epoch: 3 [42240/60000 (70%)]	Loss: 110.469223
Train Epoch: 3 [43520/60000 (72%)]	Loss: 117.007614
Train Epoch: 3 [44800/60000 (75%)]	Loss: 109.502289
Train Epoch: 3 [46080/60000 (77%)]	Loss: 111.245079
Train Epoch: 3 [47360/60000 (79%)]	Loss: 109.745903
Train Epoch: 3 [48640/60000 (81%)]	Loss: 112.991272
Train Epoch: 3 [49920/60000 (83%)]	Loss: 114.212898
Train Epoch: 3 [51200/60000 (85%)]	Loss: 115.515068
Train Epoch: 3 [52480/60000 (87%)]	Loss: 112.687134
Train Epoch: 3 [53760/60000 (90%)]	Loss: 111.000427
Train Epoch: 3 [55040/60000 (92%)]	Loss: 111.418076
Train Epoch: 3 [56320/60000 (94%)]	Loss: 110.545959
Train Epoch: 3 [57600/60000 (96%)]	Loss: 112.606064
Train Epoch: 3 [58880/60000 (98%)]	Loss: 114.056656
====> Epoch: 3 Average loss: 114.5048
====> Test set loss: 111.9490
Train Epoch: 4 [0/60000 (0%)]	Loss: 120.047394
Train Epoch: 4 [1280/60000 (2%)]	Loss: 113.439438
Train Epoch: 4 [2560/60000 (4%)]	Loss: 114.541901
Train Epoch: 4 [3840/60000 (6%)]	Loss: 112.383453
Train Epoch: 4 [5120/60000 (9%)]	Loss: 113.769760
Train Epoch: 4 [6400/60000 (11%)]	Loss: 115.446091
Train Epoch: 4 [7680/60000 (13%)]	Loss: 114.940369
Train Epoch: 4 [8960/60000 (15%)]	Loss: 111.609787
Train Epoch: 4 [10240/60000 (17%)]	Loss: 111.879196
Train Epoch: 4 [11520/60000 (19%)]	Loss: 110.062904
Train Epoch: 4 [12800/60000 (21%)]	Loss: 114.095299
Train Epoch: 4 [14080/60000 (23%)]	Loss: 109.935013
Train Epoch: 4 [15360/60000 (26%)]	Loss: 113.518860
Train Epoch: 4 [16640/60000 (28%)]	Loss: 108.036995
Train Epoch: 4 [17920/60000 (30%)]	Loss: 110.016983
Train Epoch: 4 [19200/60000 (32%)]	Loss: 108.681641
Train Epoch: 4 [20480/60000 (34%)]	Loss: 110.930550
Train Epoch: 4 [21760/60000 (36%)]	Loss: 113.866989
Train Epoch: 4 [23040/60000 (38%)]	Loss: 109.050949
Train Epoch: 4 [24320/60000 (41%)]	Loss: 114.068077
Train Epoch: 4 [25600/60000 (43%)]	Loss: 107.175262
Train Epoch: 4 [26880/60000 (45%)]	Loss: 109.503929
Train Epoch: 4 [28160/60000 (47%)]	Loss: 108.168091
Train Epoch: 4 [29440/60000 (49%)]	Loss: 111.091606
Train Epoch: 4 [30720/60000 (51%)]	Loss: 111.464699
Train Epoch: 4 [32000/60000 (53%)]	Loss: 114.337212
Train Epoch: 4 [33280/60000 (55%)]	Loss: 114.417580
Train Epoch: 4 [34560/60000 (58%)]	Loss: 104.239151
Train Epoch: 4 [35840/60000 (60%)]	Loss: 110.188248
Train Epoch: 4 [37120/60000 (62%)]	Loss: 110.396622
Train Epoch: 4 [38400/60000 (64%)]	Loss: 108.455772
Train Epoch: 4 [39680/60000 (66%)]	Loss: 109.437027
Train Epoch: 4 [40960/60000 (68%)]	Loss: 110.564468
Train Epoch: 4 [42240/60000 (70%)]	Loss: 113.839783
Train Epoch: 4 [43520/60000 (72%)]	Loss: 111.012360
Train Epoch: 4 [44800/60000 (75%)]	Loss: 114.166885
Train Epoch: 4 [46080/60000 (77%)]	Loss: 110.861481
Train Epoch: 4 [47360/60000 (79%)]	Loss: 110.126190
Train Epoch: 4 [48640/60000 (81%)]	Loss: 109.663544
Train Epoch: 4 [49920/60000 (83%)]	Loss: 109.612068
Train Epoch: 4 [51200/60000 (85%)]	Loss: 111.508446
Train Epoch: 4 [52480/60000 (87%)]	Loss: 111.252670
Train Epoch: 4 [53760/60000 (90%)]	Loss: 109.680450
Train Epoch: 4 [55040/60000 (92%)]	Loss: 107.287964
Train Epoch: 4 [56320/60000 (94%)]	Loss: 106.008064
Train Epoch: 4 [57600/60000 (96%)]	Loss: 108.027985
Train Epoch: 4 [58880/60000 (98%)]	Loss: 112.578651
====> Epoch: 4 Average loss: 111.4154
====> Test set loss: 109.5727
Train Epoch: 5 [0/60000 (0%)]	Loss: 106.913544
Train Epoch: 5 [1280/60000 (2%)]	Loss: 110.151871
Train Epoch: 5 [2560/60000 (4%)]	Loss: 110.175461
Train Epoch: 5 [3840/60000 (6%)]	Loss: 110.383133
Train Epoch: 5 [5120/60000 (9%)]	Loss: 107.265968
Train Epoch: 5 [6400/60000 (11%)]	Loss: 108.258026
Train Epoch: 5 [7680/60000 (13%)]	Loss: 108.339951
Train Epoch: 5 [8960/60000 (15%)]	Loss: 111.113358
Train Epoch: 5 [10240/60000 (17%)]	Loss: 111.274239
Train Epoch: 5 [11520/60000 (19%)]	Loss: 109.448853
Train Epoch: 5 [12800/60000 (21%)]	Loss: 114.271332
Train Epoch: 5 [14080/60000 (23%)]	Loss: 107.194366
Train Epoch: 5 [15360/60000 (26%)]	Loss: 114.231728
Train Epoch: 5 [16640/60000 (28%)]	Loss: 111.681778
Train Epoch: 5 [17920/60000 (30%)]	Loss: 107.687569
Train Epoch: 5 [19200/60000 (32%)]	Loss: 109.094765
Train Epoch: 5 [20480/60000 (34%)]	Loss: 107.436646
Train Epoch: 5 [21760/60000 (36%)]	Loss: 106.895805
Train Epoch: 5 [23040/60000 (38%)]	Loss: 112.855194
Train Epoch: 5 [24320/60000 (41%)]	Loss: 107.690804
Train Epoch: 5 [25600/60000 (43%)]	Loss: 112.251038
Train Epoch: 5 [26880/60000 (45%)]	Loss: 107.414963
Train Epoch: 5 [28160/60000 (47%)]	Loss: 107.705208
Train Epoch: 5 [29440/60000 (49%)]	Loss: 105.544144
Train Epoch: 5 [30720/60000 (51%)]	Loss: 104.193878
Train Epoch: 5 [32000/60000 (53%)]	Loss: 109.701012
Train Epoch: 5 [33280/60000 (55%)]	Loss: 113.708534
Train Epoch: 5 [34560/60000 (58%)]	Loss: 111.294983
Train Epoch: 5 [35840/60000 (60%)]	Loss: 111.079910
Train Epoch: 5 [37120/60000 (62%)]	Loss: 111.786430
Train Epoch: 5 [38400/60000 (64%)]	Loss: 110.204041
Train Epoch: 5 [39680/60000 (66%)]	Loss: 110.049553
Train Epoch: 5 [40960/60000 (68%)]	Loss: 107.104263
Train Epoch: 5 [42240/60000 (70%)]	Loss: 111.502151
Train Epoch: 5 [43520/60000 (72%)]	Loss: 107.646225
Train Epoch: 5 [44800/60000 (75%)]	Loss: 106.721817
Train Epoch: 5 [46080/60000 (77%)]	Loss: 108.029442
Train Epoch: 5 [47360/60000 (79%)]	Loss: 107.458740
Train Epoch: 5 [48640/60000 (81%)]	Loss: 115.585342
Train Epoch: 5 [49920/60000 (83%)]	Loss: 108.677094
Train Epoch: 5 [51200/60000 (85%)]	Loss: 112.571243
Train Epoch: 5 [52480/60000 (87%)]	Loss: 107.516907
Train Epoch: 5 [53760/60000 (90%)]	Loss: 107.201118
Train Epoch: 5 [55040/60000 (92%)]	Loss: 109.329269
Train Epoch: 5 [56320/60000 (94%)]	Loss: 109.132057
Train Epoch: 5 [57600/60000 (96%)]	Loss: 109.615196
Train Epoch: 5 [58880/60000 (98%)]	Loss: 112.417358
====> Epoch: 5 Average loss: 109.6029
====> Test set loss: 108.4172
Train Epoch: 6 [0/60000 (0%)]	Loss: 107.150780
Train Epoch: 6 [1280/60000 (2%)]	Loss: 106.237411
Train Epoch: 6 [2560/60000 (4%)]	Loss: 112.050880
Train Epoch: 6 [3840/60000 (6%)]	Loss: 108.819489
Train Epoch: 6 [5120/60000 (9%)]	Loss: 104.942078
Train Epoch: 6 [6400/60000 (11%)]	Loss: 108.964203
Train Epoch: 6 [7680/60000 (13%)]	Loss: 113.656052
Train Epoch: 6 [8960/60000 (15%)]	Loss: 107.706787
Train Epoch: 6 [10240/60000 (17%)]	Loss: 112.692108
Train Epoch: 6 [11520/60000 (19%)]	Loss: 108.184532
Train Epoch: 6 [12800/60000 (21%)]	Loss: 107.133255
Train Epoch: 6 [14080/60000 (23%)]	Loss: 112.607330
Train Epoch: 6 [15360/60000 (26%)]	Loss: 104.834808
Train Epoch: 6 [16640/60000 (28%)]	Loss: 108.533546
Train Epoch: 6 [17920/60000 (30%)]	Loss: 106.833405
Train Epoch: 6 [19200/60000 (32%)]	Loss: 107.552475
Train Epoch: 6 [20480/60000 (34%)]	Loss: 107.174065
Train Epoch: 6 [21760/60000 (36%)]	Loss: 109.359253
Train Epoch: 6 [23040/60000 (38%)]	Loss: 104.597275
Train Epoch: 6 [24320/60000 (41%)]	Loss: 108.276413
Train Epoch: 6 [25600/60000 (43%)]	Loss: 103.988266
Train Epoch: 6 [26880/60000 (45%)]	Loss: 108.371010
Train Epoch: 6 [28160/60000 (47%)]	Loss: 110.586876
Train Epoch: 6 [29440/60000 (49%)]	Loss: 110.776978
Train Epoch: 6 [30720/60000 (51%)]	Loss: 113.108154
Train Epoch: 6 [32000/60000 (53%)]	Loss: 110.371643
Train Epoch: 6 [33280/60000 (55%)]	Loss: 109.138298
Train Epoch: 6 [34560/60000 (58%)]	Loss: 110.980934
Train Epoch: 6 [35840/60000 (60%)]	Loss: 104.909256
Train Epoch: 6 [37120/60000 (62%)]	Loss: 104.492416
Train Epoch: 6 [38400/60000 (64%)]	Loss: 111.342163
Train Epoch: 6 [39680/60000 (66%)]	Loss: 109.369850
Train Epoch: 6 [40960/60000 (68%)]	Loss: 110.440308
Train Epoch: 6 [42240/60000 (70%)]	Loss: 113.243546
Train Epoch: 6 [43520/60000 (72%)]	Loss: 110.688828
Train Epoch: 6 [44800/60000 (75%)]	Loss: 105.253815
Train Epoch: 6 [46080/60000 (77%)]	Loss: 106.637772
Train Epoch: 6 [47360/60000 (79%)]	Loss: 105.473022
Train Epoch: 6 [48640/60000 (81%)]	Loss: 104.707901
Train Epoch: 6 [49920/60000 (83%)]	Loss: 106.658142
Train Epoch: 6 [51200/60000 (85%)]	Loss: 105.572479
Train Epoch: 6 [52480/60000 (87%)]	Loss: 108.438316
Train Epoch: 6 [53760/60000 (90%)]	Loss: 109.064621
Train Epoch: 6 [55040/60000 (92%)]	Loss: 108.002197
Train Epoch: 6 [56320/60000 (94%)]	Loss: 106.593864
Train Epoch: 6 [57600/60000 (96%)]	Loss: 110.728157
Train Epoch: 6 [58880/60000 (98%)]	Loss: 105.356476
====> Epoch: 6 Average loss: 108.4728
====> Test set loss: 107.1688
Train Epoch: 7 [0/60000 (0%)]	Loss: 107.408936
Train Epoch: 7 [1280/60000 (2%)]	Loss: 105.829765
Train Epoch: 7 [2560/60000 (4%)]	Loss: 106.246918
Train Epoch: 7 [3840/60000 (6%)]	Loss: 103.284935
Train Epoch: 7 [5120/60000 (9%)]	Loss: 107.743454
Train Epoch: 7 [6400/60000 (11%)]	Loss: 106.924606
Train Epoch: 7 [7680/60000 (13%)]	Loss: 108.836159
Train Epoch: 7 [8960/60000 (15%)]	Loss: 105.857254
Train Epoch: 7 [10240/60000 (17%)]	Loss: 108.116241
Train Epoch: 7 [11520/60000 (19%)]	Loss: 107.278000
Train Epoch: 7 [12800/60000 (21%)]	Loss: 105.864525
Train Epoch: 7 [14080/60000 (23%)]	Loss: 110.058975
Train Epoch: 7 [15360/60000 (26%)]	Loss: 106.656685
Train Epoch: 7 [16640/60000 (28%)]	Loss: 109.578911
Train Epoch: 7 [17920/60000 (30%)]	Loss: 108.205994
Train Epoch: 7 [19200/60000 (32%)]	Loss: 110.024979
Train Epoch: 7 [20480/60000 (34%)]	Loss: 109.088387
Train Epoch: 7 [21760/60000 (36%)]	Loss: 107.321671
Train Epoch: 7 [23040/60000 (38%)]	Loss: 108.092712
Train Epoch: 7 [24320/60000 (41%)]	Loss: 110.293327
Train Epoch: 7 [25600/60000 (43%)]	Loss: 103.029137
Train Epoch: 7 [26880/60000 (45%)]	Loss: 104.876968
Train Epoch: 7 [28160/60000 (47%)]	Loss: 101.822617
Train Epoch: 7 [29440/60000 (49%)]	Loss: 108.571152
Train Epoch: 7 [30720/60000 (51%)]	Loss: 106.168808
Train Epoch: 7 [32000/60000 (53%)]	Loss: 108.003624
Train Epoch: 7 [33280/60000 (55%)]	Loss: 110.074730
Train Epoch: 7 [34560/60000 (58%)]	Loss: 108.114990
Train Epoch: 7 [35840/60000 (60%)]	Loss: 106.857643
Train Epoch: 7 [37120/60000 (62%)]	Loss: 107.785645
Train Epoch: 7 [38400/60000 (64%)]	Loss: 110.604424
Train Epoch: 7 [39680/60000 (66%)]	Loss: 105.766739
Train Epoch: 7 [40960/60000 (68%)]	Loss: 110.149384
Train Epoch: 7 [42240/60000 (70%)]	Loss: 109.259239
Train Epoch: 7 [43520/60000 (72%)]	Loss: 107.872215
Train Epoch: 7 [44800/60000 (75%)]	Loss: 107.493530
Train Epoch: 7 [46080/60000 (77%)]	Loss: 110.423637
Train Epoch: 7 [47360/60000 (79%)]	Loss: 106.516037
Train Epoch: 7 [48640/60000 (81%)]	Loss: 106.081245
Train Epoch: 7 [49920/60000 (83%)]	Loss: 106.945190
Train Epoch: 7 [51200/60000 (85%)]	Loss: 106.157944
Train Epoch: 7 [52480/60000 (87%)]	Loss: 106.119301
Train Epoch: 7 [53760/60000 (90%)]	Loss: 106.488899
Train Epoch: 7 [55040/60000 (92%)]	Loss: 110.874664
Train Epoch: 7 [56320/60000 (94%)]	Loss: 106.162056
Train Epoch: 7 [57600/60000 (96%)]	Loss: 108.550949
Train Epoch: 7 [58880/60000 (98%)]	Loss: 108.446571
====> Epoch: 7 Average loss: 107.6607
====> Test set loss: 106.7563
Train Epoch: 8 [0/60000 (0%)]	Loss: 107.899284
Train Epoch: 8 [1280/60000 (2%)]	Loss: 104.979248
Train Epoch: 8 [2560/60000 (4%)]	Loss: 104.040741
Train Epoch: 8 [3840/60000 (6%)]	Loss: 105.475876
Train Epoch: 8 [5120/60000 (9%)]	Loss: 106.743362
Train Epoch: 8 [6400/60000 (11%)]	Loss: 107.749451
Train Epoch: 8 [7680/60000 (13%)]	Loss: 108.066818
Train Epoch: 8 [8960/60000 (15%)]	Loss: 105.239983
Train Epoch: 8 [10240/60000 (17%)]	Loss: 105.239159
Train Epoch: 8 [11520/60000 (19%)]	Loss: 108.289688
Train Epoch: 8 [12800/60000 (21%)]	Loss: 106.744499
Train Epoch: 8 [14080/60000 (23%)]	Loss: 102.587440
Train Epoch: 8 [15360/60000 (26%)]	Loss: 107.179680
Train Epoch: 8 [16640/60000 (28%)]	Loss: 108.063065
Train Epoch: 8 [17920/60000 (30%)]	Loss: 105.248695
Train Epoch: 8 [19200/60000 (32%)]	Loss: 110.379395
Train Epoch: 8 [20480/60000 (34%)]	Loss: 102.525887
Train Epoch: 8 [21760/60000 (36%)]	Loss: 105.764305
Train Epoch: 8 [23040/60000 (38%)]	Loss: 107.133286
Train Epoch: 8 [24320/60000 (41%)]	Loss: 108.225815
Train Epoch: 8 [25600/60000 (43%)]	Loss: 107.388374
Train Epoch: 8 [26880/60000 (45%)]	Loss: 105.654518
Train Epoch: 8 [28160/60000 (47%)]	Loss: 109.068787
Train Epoch: 8 [29440/60000 (49%)]	Loss: 103.657928
Train Epoch: 8 [30720/60000 (51%)]	Loss: 107.568947
Train Epoch: 8 [32000/60000 (53%)]	Loss: 107.957954
Train Epoch: 8 [33280/60000 (55%)]	Loss: 106.448792
Train Epoch: 8 [34560/60000 (58%)]	Loss: 109.272568
Train Epoch: 8 [35840/60000 (60%)]	Loss: 106.956573
Train Epoch: 8 [37120/60000 (62%)]	Loss: 105.398659
Train Epoch: 8 [38400/60000 (64%)]	Loss: 108.339546
Train Epoch: 8 [39680/60000 (66%)]	Loss: 108.675278
Train Epoch: 8 [40960/60000 (68%)]	Loss: 105.023239
Train Epoch: 8 [42240/60000 (70%)]	Loss: 110.508362
Train Epoch: 8 [43520/60000 (72%)]	Loss: 107.428207
Train Epoch: 8 [44800/60000 (75%)]	Loss: 103.197243
Train Epoch: 8 [46080/60000 (77%)]	Loss: 105.084564
Train Epoch: 8 [47360/60000 (79%)]	Loss: 107.114136
Train Epoch: 8 [48640/60000 (81%)]	Loss: 108.587425
Train Epoch: 8 [49920/60000 (83%)]	Loss: 105.279160
Train Epoch: 8 [51200/60000 (85%)]	Loss: 106.611420
Train Epoch: 8 [52480/60000 (87%)]	Loss: 104.311440
Train Epoch: 8 [53760/60000 (90%)]	Loss: 104.925262
Train Epoch: 8 [55040/60000 (92%)]	Loss: 104.283257
Train Epoch: 8 [56320/60000 (94%)]	Loss: 108.132996
Train Epoch: 8 [57600/60000 (96%)]	Loss: 106.261459
Train Epoch: 8 [58880/60000 (98%)]	Loss: 105.814392
====> Epoch: 8 Average loss: 106.9838
====> Test set loss: 106.1856
Train Epoch: 9 [0/60000 (0%)]	Loss: 107.541580
Train Epoch: 9 [1280/60000 (2%)]	Loss: 102.941292
Train Epoch: 9 [2560/60000 (4%)]	Loss: 107.820679
Train Epoch: 9 [3840/60000 (6%)]	Loss: 102.380104
Train Epoch: 9 [5120/60000 (9%)]	Loss: 103.587997
Train Epoch: 9 [6400/60000 (11%)]	Loss: 106.634888
Train Epoch: 9 [7680/60000 (13%)]	Loss: 107.779266
Train Epoch: 9 [8960/60000 (15%)]	Loss: 107.058151
Train Epoch: 9 [10240/60000 (17%)]	Loss: 107.422653
Train Epoch: 9 [11520/60000 (19%)]	Loss: 110.055817
Train Epoch: 9 [12800/60000 (21%)]	Loss: 105.313782
Train Epoch: 9 [14080/60000 (23%)]	Loss: 103.882195
Train Epoch: 9 [15360/60000 (26%)]	Loss: 108.060120
Train Epoch: 9 [16640/60000 (28%)]	Loss: 106.737595
Train Epoch: 9 [17920/60000 (30%)]	Loss: 107.736343
Train Epoch: 9 [19200/60000 (32%)]	Loss: 106.621368
Train Epoch: 9 [20480/60000 (34%)]	Loss: 112.870605
Train Epoch: 9 [21760/60000 (36%)]	Loss: 109.426666
Train Epoch: 9 [23040/60000 (38%)]	Loss: 110.227509
Train Epoch: 9 [24320/60000 (41%)]	Loss: 102.989136
Train Epoch: 9 [25600/60000 (43%)]	Loss: 108.878334
Train Epoch: 9 [26880/60000 (45%)]	Loss: 105.945641
Train Epoch: 9 [28160/60000 (47%)]	Loss: 106.984146
Train Epoch: 9 [29440/60000 (49%)]	Loss: 102.544098
Train Epoch: 9 [30720/60000 (51%)]	Loss: 108.202759
Train Epoch: 9 [32000/60000 (53%)]	Loss: 106.708824
Train Epoch: 9 [33280/60000 (55%)]	Loss: 107.619438
Train Epoch: 9 [34560/60000 (58%)]	Loss: 101.608727
Train Epoch: 9 [35840/60000 (60%)]	Loss: 107.532860
Train Epoch: 9 [37120/60000 (62%)]	Loss: 108.405731
Train Epoch: 9 [38400/60000 (64%)]	Loss: 105.450775
Train Epoch: 9 [39680/60000 (66%)]	Loss: 105.973396
Train Epoch: 9 [40960/60000 (68%)]	Loss: 106.573372
Train Epoch: 9 [42240/60000 (70%)]	Loss: 106.664482
Train Epoch: 9 [43520/60000 (72%)]	Loss: 105.119095
Train Epoch: 9 [44800/60000 (75%)]	Loss: 103.314903
Train Epoch: 9 [46080/60000 (77%)]	Loss: 108.241318
Train Epoch: 9 [47360/60000 (79%)]	Loss: 107.146408
Train Epoch: 9 [48640/60000 (81%)]	Loss: 106.338852
Train Epoch: 9 [49920/60000 (83%)]	Loss: 106.482063
Train Epoch: 9 [51200/60000 (85%)]	Loss: 103.652969
Train Epoch: 9 [52480/60000 (87%)]	Loss: 104.320969
Train Epoch: 9 [53760/60000 (90%)]	Loss: 104.427353
Train Epoch: 9 [55040/60000 (92%)]	Loss: 100.878098
Train Epoch: 9 [56320/60000 (94%)]	Loss: 104.397385
Train Epoch: 9 [57600/60000 (96%)]	Loss: 107.585007
Train Epoch: 9 [58880/60000 (98%)]	Loss: 103.400970
====> Epoch: 9 Average loss: 106.4775
====> Test set loss: 106.0674
Train Epoch: 10 [0/60000 (0%)]	Loss: 103.728432
Train Epoch: 10 [1280/60000 (2%)]	Loss: 106.395348
Train Epoch: 10 [2560/60000 (4%)]	Loss: 105.388290
Train Epoch: 10 [3840/60000 (6%)]	Loss: 106.115608
Train Epoch: 10 [5120/60000 (9%)]	Loss: 106.691666
Train Epoch: 10 [6400/60000 (11%)]	Loss: 106.975655
Train Epoch: 10 [7680/60000 (13%)]	Loss: 105.457291
Train Epoch: 10 [8960/60000 (15%)]	Loss: 105.918594
Train Epoch: 10 [10240/60000 (17%)]	Loss: 108.195404
Train Epoch: 10 [11520/60000 (19%)]	Loss: 103.411369
Train Epoch: 10 [12800/60000 (21%)]	Loss: 104.274170
Train Epoch: 10 [14080/60000 (23%)]	Loss: 106.320824
Train Epoch: 10 [15360/60000 (26%)]	Loss: 105.991592
Train Epoch: 10 [16640/60000 (28%)]	Loss: 108.397949
Train Epoch: 10 [17920/60000 (30%)]	Loss: 106.172379
Train Epoch: 10 [19200/60000 (32%)]	Loss: 106.414986
Train Epoch: 10 [20480/60000 (34%)]	Loss: 104.865807
Train Epoch: 10 [21760/60000 (36%)]	Loss: 104.453087
Train Epoch: 10 [23040/60000 (38%)]	Loss: 106.033783
Train Epoch: 10 [24320/60000 (41%)]	Loss: 105.129906
Train Epoch: 10 [25600/60000 (43%)]	Loss: 105.693954
Train Epoch: 10 [26880/60000 (45%)]	Loss: 102.869789
Train Epoch: 10 [28160/60000 (47%)]	Loss: 108.188965
Train Epoch: 10 [29440/60000 (49%)]	Loss: 107.724869
Train Epoch: 10 [30720/60000 (51%)]	Loss: 108.226868
Train Epoch: 10 [32000/60000 (53%)]	Loss: 107.527931
Train Epoch: 10 [33280/60000 (55%)]	Loss: 103.218681
Train Epoch: 10 [34560/60000 (58%)]	Loss: 108.287979
Train Epoch: 10 [35840/60000 (60%)]	Loss: 107.876060
Train Epoch: 10 [37120/60000 (62%)]	Loss: 106.314049
Train Epoch: 10 [38400/60000 (64%)]	Loss: 108.712723
Train Epoch: 10 [39680/60000 (66%)]	Loss: 106.245323
Train Epoch: 10 [40960/60000 (68%)]	Loss: 106.572289
Train Epoch: 10 [42240/60000 (70%)]	Loss: 107.665848
Train Epoch: 10 [43520/60000 (72%)]	Loss: 104.337692
Train Epoch: 10 [44800/60000 (75%)]	Loss: 108.312622
Train Epoch: 10 [46080/60000 (77%)]	Loss: 105.260063
Train Epoch: 10 [47360/60000 (79%)]	Loss: 107.999985
Train Epoch: 10 [48640/60000 (81%)]	Loss: 102.944756
Train Epoch: 10 [49920/60000 (83%)]	Loss: 107.691856
Train Epoch: 10 [51200/60000 (85%)]	Loss: 105.387268
Train Epoch: 10 [52480/60000 (87%)]	Loss: 106.625946
Train Epoch: 10 [53760/60000 (90%)]	Loss: 105.363693
Train Epoch: 10 [55040/60000 (92%)]	Loss: 106.690437
Train Epoch: 10 [56320/60000 (94%)]	Loss: 109.625511
Train Epoch: 10 [57600/60000 (96%)]	Loss: 112.336594
Train Epoch: 10 [58880/60000 (98%)]	Loss: 107.636566
====> Epoch: 10 Average loss: 106.1004
====> Test set loss: 105.5604
```

</details>