### PR TITLE
add --device

### DIFF
--- a/dcgan/README.md
+++ b/dcgan/README.md
@@ -24,7 +24,7 @@ usage: main.py [-h] --dataset DATASET --dataroot DATAROOT [--workers WORKERS]
                [--batchSize BATCHSIZE] [--imageSize IMAGESIZE] [--nz NZ]
                [--ngf NGF] [--ndf NDF] [--niter NITER] [--lr LR]
                [--beta1 BETA1] [--cuda] [--ngpu NGPU] [--netG NETG]
-               [--netD NETD] [--mps]
+               [--netD NETD] [--mps] [--device DEVICE]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -41,6 +41,7 @@ optional arguments:
   --beta1 BETA1         beta1 for adam. default=0.5
   --cuda                enables cuda
   --mps                 enables macOS GPU
+  --device              backend device
   --ngpu NGPU           number of GPUs to use
   --netG NETG           path to netG (to continue training)
   --netD NETD           path to netD (to continue training)

--- a/dcgan/main.py
+++ b/dcgan/main.py
@@ -34,6 +34,7 @@ parser.add_argument('--outf', default='.', help='folder to output images and mod
 parser.add_argument('--manualSeed', type=int, help='manual seed')
 parser.add_argument('--classes', default='bedroom', help='comma separated list of classes for the lsun data set')
 parser.add_argument('--mps', action='store_true', default=False, help='enables macOS GPU training')
+parser.add_argument('--device', type=str, default='cpu', help='backend device')
 
 opt = parser.parse_args()
 print(opt)
@@ -112,7 +113,7 @@ if opt.cuda:
 elif use_mps:
     device = torch.device("mps")
 else:
-    device = torch.device("cpu")
+    device = torch.device(opt.device)
 
 ngpu = int(opt.ngpu)
 nz = int(opt.nz)

--- a/gat/README.md
+++ b/gat/README.md
@@ -69,7 +69,7 @@ python main.py --epochs 300 --lr 0.005 --l2 5e-4 --dropout-p 0.6 --num-heads 8 -
 In more detail, the `main.py` script recieves following arguments:
 ```
 usage: main.py [-h] [--epochs EPOCHS] [--lr LR] [--l2 L2] [--dropout-p DROPOUT_P] [--hidden-dim HIDDEN_DIM] [--num-heads NUM_HEADS] [--concat-heads] [--val-every VAL_EVERY]
-               [--no-cuda] [--no-mps] [--dry-run] [--seed S]
+               [--no-cuda] [--no-mps] [--dry-run] [--seed S] [--device DEVICE]
 
 PyTorch Graph Attention Network
 
@@ -89,6 +89,7 @@ options:
                         epochs to wait for print training and validation evaluation (default: 20)
   --no-cuda             disables CUDA training
   --no-mps              disables macOS GPU training
+  --device DEVICE       backend device
   --dry-run             quickly check a single pass
   --seed S              random seed (default: 13)
 ```

--- a/gat/main.py
+++ b/gat/main.py
@@ -311,6 +311,8 @@ if __name__ == '__main__':
                         help='disables CUDA training')
     parser.add_argument('--no-mps', action='store_true', default=False,
                         help='disables macOS GPU training')
+    parser.add_argument('--device', type=str, default='cpu',
+                        help='backend device')
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=13, metavar='S',
@@ -327,7 +329,7 @@ if __name__ == '__main__':
     elif use_mps:
         device = torch.device('mps')
     else:
-        device = torch.device('cpu')
+        device = torch.device(args.device)
     print(f'Using {device} device')
 
     # Load the dataset

--- a/gcn/main.py
+++ b/gcn/main.py
@@ -220,6 +220,8 @@ if __name__ == '__main__':
                         help='disables CUDA training')
     parser.add_argument('--no-mps', action='store_true', default=False,
                         help='disables macOS GPU training')
+    parser.add_argument('--device', type=str, default='cpu',
+                        help='backend device')
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=42, metavar='S',
@@ -236,7 +238,7 @@ if __name__ == '__main__':
     elif use_mps:
         device = torch.device('mps')
     else:
-        device = torch.device('cpu')
+        device = torch.device(args.device)
     print(f'Using {device} device')
 
     cora_url = 'https://linqs-data.soe.ucsc.edu/public/lbc/cora.tgz'

--- a/language_translation/main.py
+++ b/language_translation/main.py
@@ -272,9 +272,9 @@ if __name__ == "__main__":
                         help="Default learning rate")
     parser.add_argument("--batch", type=int, default=128,
                         help="Batch size")
-    parser.add_argument("--backend", type=str, default="cpu",
-                        help="Batch size")
-    
+    parser.add_argument("--device", type=str, default="cpu",
+                        help="backend device")
+
     # Transformer settings
     parser.add_argument("--attn_heads", type=int, default=8,
                         help="Number of attention heads")
@@ -298,7 +298,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if args.backend == "gpu" and torch.cuda.is_available() else "cpu")
+    DEVICE = torch.device("cuda" if args.device == "gpu" and torch.cuda.is_available() else args.device)
 
     if args.inference:
         inference(args)

--- a/legacy/snli/README.md
+++ b/legacy/snli/README.md
@@ -25,7 +25,7 @@ spacy
 Start the training process with:
 
 ```bash
-python train.py --lower --word-vectors [PATH_TO_WORD_VECTORS] --vector-cache [PATH_TO_VECTOR_CACHE] --epochs [NUMBER_OF_EPOCHS] --batch-size [BATCH_SIZE] --save-path [PATH_TO_SAVE_MODEL] --gpu [GPU_NUMBER]
+python train.py --lower --word-vectors [PATH_TO_WORD_VECTORS] --vector-cache [PATH_TO_VECTOR_CACHE] --epochs [NUMBER_OF_EPOCHS] --batch-size [BATCH_SIZE] --save-path [PATH_TO_SAVE_MODEL] --gpu [GPU_NUMBER] --device [BACKEND_DEVICE]
 ```
 
 ## 🏋️‍♀️ Training

--- a/legacy/snli/train.py
+++ b/legacy/snli/train.py
@@ -20,7 +20,7 @@ if torch.cuda.is_available():
 elif torch.backends.mps.is_available():
     device = torch.device('mps')
 else:
-    device = torch.device('cpu')
+    device = torch.device(args.device)
 
 inputs = data.Field(lower=args.lower, tokenize='spacy')
 answers = data.Field(sequential=False)

--- a/legacy/snli/util.py
+++ b/legacy/snli/util.py
@@ -20,6 +20,8 @@ def makedirs(name):
 
 def get_args():
     parser = ArgumentParser(description='PyTorch/torchtext SNLI example')
+    parser.add_argument('--device', type=str, default='cpu',
+                        help='backend device')
     parser.add_argument('--epochs', type=int, default=50,
                         help='the number of total epochs to run.')
     parser.add_argument('--batch_size', type=int, default=128,

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -86,6 +86,8 @@ def main():
                         help='disables CUDA training')
     parser.add_argument('--no-mps', action='store_true', default=False,
                         help='disables macOS GPU training')
+    parser.add_argument('--device', type=str, default='cpu',
+                        help='backend device')
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
@@ -105,7 +107,7 @@ def main():
     elif use_mps:
         device = torch.device("mps")
     else:
-        device = torch.device("cpu")
+        device = torch.device(args.device)
 
     train_kwargs = {'batch_size': args.batch_size}
     test_kwargs = {'batch_size': args.test_batch_size}

--- a/mnist_forward_forward/README.md
+++ b/mnist_forward_forward/README.md
@@ -18,6 +18,7 @@ optional arguments:
   --lr LR               learning rate (default: 0.03)
   --no_cuda             disables CUDA training
   --no_mps              disables MPS training
+  --device DEVICE       backend device
   --seed SEED           random seed (default: 1)
   --save_model          For saving the current Model
   --train_size TRAIN_SIZE

--- a/mnist_forward_forward/main.py
+++ b/mnist_forward_forward/main.py
@@ -109,6 +109,9 @@ if __name__ == "__main__":
         "--no_mps", action="store_true", default=False, help="disables MPS training"
     )
     parser.add_argument(
+        '--device', type=str, default='cpu', help='backend device'
+    )
+    parser.add_argument(
         "--seed", type=int, default=1, metavar="S", help="random seed (default: 1)"
     )
     parser.add_argument(
@@ -145,7 +148,7 @@ if __name__ == "__main__":
     elif use_mps:
         device = torch.device("mps")
     else:
-        device = torch.device("cpu")
+        device = torch.device(args.device)
 
     train_kwargs = {"batch_size": args.train_size}
     test_kwargs = {"batch_size": args.test_size}

--- a/mnist_hogwild/README.md
+++ b/mnist_hogwild/README.md
@@ -21,6 +21,7 @@ optional arguments:
   --log_interval        how many batches to wait before logging training status
   --num_process         how many training processes to use (default: 2)
   --cuda                enables CUDA training
+  --device DEVICE       backend device
   --dry-run             quickly check a single pass
   --save-model          For Saving the current Model
 ```

--- a/mnist_hogwild/main.py
+++ b/mnist_hogwild/main.py
@@ -31,6 +31,8 @@ parser.add_argument('--cuda', action='store_true', default=False,
                     help='enables CUDA training')
 parser.add_argument('--mps', action='store_true', default=False,
                     help='enables macOS GPU training')
+parser.add_argument('--device', type=str, default='cpu',
+                    help='backend device')
 parser.add_argument('--save_model', action='store_true', default=False,
                     help='save the trained model to state_dict')
 parser.add_argument('--dry-run', action='store_true', default=False,
@@ -65,7 +67,7 @@ if __name__ == '__main__':
     elif use_mps:
         device = torch.device("mps")
     else:
-        device = torch.device("cpu")
+        device = torch.device(args.device)
 
     transform=transforms.Compose([
         transforms.ToTensor(),

--- a/mnist_rnn/main.py
+++ b/mnist_rnn/main.py
@@ -95,6 +95,8 @@ def main():
                         help='enables CUDA training')
     parser.add_argument('--mps', action="store_true", default=False,
                         help="enables MPS training")
+    parser.add_argument('--device', type=str, default='cpu',
+                        help='backend device')
     parser.add_argument('--dry-run', action='store_true', default=False,
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
@@ -110,7 +112,7 @@ def main():
     elif args.mps and not args.cuda:
         device = "mps"
     else:
-        device = "cpu"
+        device = args.device
 
     device = torch.device(device)
 


### PR DESCRIPTION
- dcgan
- gat
- gcn
- language_translation

```bash
BACKEND_DEVICE=npu ./run_python_examples.sh "run_all"
```

```
Finished run_all, status 0
Some python examples failed:
saved models not found
mnist hogwild failed
graph convolutional network failed
```

### Errors

#### 1. gcn

```
root@3dfeb58e2e6e:~/pytorch-examples/gcn# python main.py --device npu
[W920 02:46:29.176903976 OperatorEntry.cpp:155] Warning: Warning only once for all operators,  other operators may also be overridden.
  Overriding a previously registered kernel for the same operator and the same dispatch key
  operator: aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
    registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
  dispatch key: CPU
  previous kernel: registered at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:497
       new kernel: registered at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:100 (function operator())
Using npu device
Downloading dataset...
Loading dataset...
Traceback (most recent call last):
  File "/root/pytorch-examples/gcn/main.py", line 260, in <module>
    train_iter(epoch + 1, gcn, optimizer, criterion, (features, adj_mat), labels, idx_train, idx_val, args.val_every)
  File "/root/pytorch-examples/gcn/main.py", line 175, in train_iter
    output = model(*input)
  File "/usr/local/python3.9/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/python3.9/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/pytorch-examples/gcn/main.py", line 104, in forward
    x = self.gc1(input_tensor, adj_mat)
  File "/usr/local/python3.9/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/python3.9/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/pytorch-examples/gcn/main.py", line 58, in forward
    support = torch.mm(input_tensor, self.kernel) # Matrix multiplication between input and weight matrix
RuntimeError: CAUTION: The operator 'aten::addmm' is not currently supported on the NPU backend.
[ERROR] 2024-09-20-02:46:48 (PID:146560, Device:0, RankID:-1) ERR01007 OPS feature not supported
```

#### 2. language_translation

> 上游 CI 已经不跑这个 example 了

no arm64:

<img width="524" alt="image" src="https://github.com/user-attachments/assets/e6ee95ab-cdf0-480b-941f-c74b3ea5fe43">

#### 3. mnist_hogwild

```
root@3dfeb58e2e6e:~/pytorch-examples/mnist_hogwild# python main.py --device npu
[W920 06:22:43.455693712 OperatorEntry.cpp:155] Warning: Warning only once for all operators,  other operators may also be overridden.
  Overriding a previously registered kernel for the same operator and the same dispatch key
  operator: aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
    registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
  dispatch key: CPU
  previous kernel: registered at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:497
       new kernel: registered at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:100 (function operator())
Traceback (most recent call last):
  File "/root/pytorch-examples/mnist_hogwild/main.py", line 91, in <module>
    model.share_memory() # gradients are allocated lazily, so they are not shared here
  File "/usr/local/python3.9/lib/python3.9/site-packages/torch_npu/utils/npu_intercept.py", line 78, in wrapper
    raise RuntimeError(f"{str(func)} is not supported in npu." + pta_error(ErrCode.NOT_SUPPORT))
RuntimeError: <function Module.share_memory at 0xfffdff9013a0> is not supported in npu.
[ERROR] 2024-09-20-06:22:53 (PID:150151, Device:0, RankID:-1) ERR00007 PTA feature not supported
```
